### PR TITLE
Configure proxy for API requests

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000',
+  baseURL: import.meta.env.VITE_API_URL || '/api',
 });
 
 api.interceptors.request.use((config) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,4 +15,13 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (pathname) => pathname.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- point the Axios client to a relative /api base path so requests can be proxied during development
- add a Vite dev server proxy from /api to the backend running on :8000 to avoid CORS failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b050de7c8325853d44715b6f2766