### PR TITLE
Fix dev API proxy path for auth requests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
-        rewrite: (pathname) => pathname.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary
- remove the dev server proxy rewrite so that /api requests keep their prefix when forwarded to the backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b1ef3194832595bf066698105f6d