### PR TITLE
Fix Vite proxy path for auth requests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
       },
     },
   },


### PR DESCRIPTION
## Summary
- update the Vite dev-server proxy to strip the `/api` prefix before forwarding requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b34a12f483259721adf93a0adbbd