### PR TITLE
Fix login payload handling and match backend CORS port

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -28,7 +28,17 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {
-    const { data } = await api.post<AuthResponse>('/auth/login', { username, password });
+    const formData = new URLSearchParams();
+    formData.append('username', username);
+    formData.append('password', password);
+
+    const { data } = await api.post<AuthResponse>(
+      '/auth/login',
+      formData,
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      },
+    );
     localStorage.setItem('access_token', data.access_token);
     localStorage.setItem('user', JSON.stringify(data.user));
     setUser(data.user);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
   },
   server: {
+    port: 3000,
     proxy: {
       '/api': {
         target: 'http://localhost:8000',


### PR DESCRIPTION
## Summary
- send authentication credentials as URL encoded form data to match the backend OAuth2 password flow requirements
- configure the Vite development server to run on port 3000 so the backend CORS policy accepts requests from the frontend

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c0b63460832592d4fd9ad85e1685