### PR TITLE
Normalize API user roles before enforcing guards

### DIFF
--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -1,15 +1,29 @@
 export type Role = 'admin' | 'docente' | 'padre';
 
+export type ApiRole =
+  | Role
+  | 'ADMIN'
+  | 'ADMINISTRADOR'
+  | 'Administrador'
+  | 'Docente'
+  | 'DOCENTE'
+  | 'Padre'
+  | 'PADRE';
+
 export interface User {
   id: number;
   name: string;
   role: Role;
 }
 
+export interface ApiUser extends Omit<User, 'role'> {
+  role: ApiRole;
+}
+
 export interface AuthResponse {
   access_token: string;
   token_type: 'bearer' | string;
-  user: User;
+  user: ApiUser;
 }
 
 export interface Paginated<TItem> {


### PR DESCRIPTION
## Summary
- normalize the user information returned by the API so role guards keep working even when the backend sends uppercase or Spanish role names
- broaden the auth types to describe raw API roles before converting them into the internal role union

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5db14976083259cf5559b49540119