### PR TITLE
Evitar mensaje vacío cuando hay error en listados

### DIFF
--- a/src/pages/courses/CoursesList.tsx
+++ b/src/pages/courses/CoursesList.tsx
@@ -35,7 +35,7 @@ export default function CoursesList() {
 
   const courses: Course[] = data?.items ?? [];
   const pageSize = data?.page_size ?? COURSES_PAGE_SIZE;
-  const isEmpty = !isLoading && courses.length === 0;
+  const isEmpty = !isLoading && !isError && courses.length === 0;
   const disablePrevious = page === 1 || isFetching;
   const disableNext = courses.length < pageSize || isFetching;
 

--- a/src/pages/students/StudentsList.tsx
+++ b/src/pages/students/StudentsList.tsx
@@ -35,7 +35,7 @@ export default function StudentsList() {
 
   const students: Student[] = data?.items ?? [];
   const pageSize = data?.page_size ?? STUDENTS_PAGE_SIZE;
-  const isEmpty = !isLoading && students.length === 0;
+  const isEmpty = !isLoading && !isError && students.length === 0;
   const disablePrevious = page === 1 || isFetching;
   const disableNext = students.length < pageSize || isFetching;
 

--- a/src/pages/subjects/SubjectsList.tsx
+++ b/src/pages/subjects/SubjectsList.tsx
@@ -43,7 +43,7 @@ export default function SubjectsList() {
 
   const subjects: Subject[] = data?.items ?? [];
   const pageSize = data?.page_size ?? SUBJECTS_PAGE_SIZE;
-  const isEmpty = !isLoading && subjects.length === 0;
+  const isEmpty = !isLoading && !isError && subjects.length === 0;
   const disablePrevious = page === 1 || isFetching;
   const disableNext = subjects.length < pageSize || isFetching;
 

--- a/src/pages/teachers/TeachersList.tsx
+++ b/src/pages/teachers/TeachersList.tsx
@@ -35,7 +35,7 @@ export default function TeachersList() {
 
   const teachers: Teacher[] = data?.items ?? [];
   const pageSize = data?.page_size ?? TEACHERS_PAGE_SIZE;
-  const isEmpty = !isLoading && teachers.length === 0;
+  const isEmpty = !isLoading && !isError && teachers.length === 0;
   const disablePrevious = page === 1 || isFetching;
   const disableNext = teachers.length < pageSize || isFetching;
 


### PR DESCRIPTION
## Summary
- evitar que los listados de estudiantes, docentes, cursos y materias muestren el mensaje de "No se encontraron" cuando la consulta falla

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e66ed16c83258a67f6557f67ccfd