### PR TITLE
Fix filters validation and improve responsive layout

### DIFF
--- a/src/app/components/Layout.tsx
+++ b/src/app/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import Sidebar from './Sidebar';
@@ -5,14 +6,31 @@ import Topbar from './Topbar';
 
 export default function Layout() {
   const { pathname } = useLocation();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  const closeSidebar = () => setIsSidebarOpen(false);
 
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
-      <div className="flex">
-        <Sidebar />
-        <main className="flex-1">
-          <Topbar />
-          <div className="p-4">
+      {/* Sidebar móvil */}
+      <Sidebar
+        className={`fixed inset-y-0 left-0 z-50 border-r shadow-lg transition-transform duration-200 lg:hidden ${isSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}
+        onNavigate={closeSidebar}
+      />
+      {isSidebarOpen && (
+        <button
+          type="button"
+          aria-label="Cerrar menú"
+          className="fixed inset-0 z-40 bg-black/40 lg:hidden"
+          onClick={closeSidebar}
+        />
+      )}
+
+      <div className="flex min-h-screen">
+        <Sidebar className="hidden lg:flex lg:h-screen lg:sticky lg:top-0 lg:border-r" />
+        <main className="flex-1 flex flex-col min-h-screen">
+          <Topbar onToggleSidebar={() => setIsSidebarOpen((current) => !current)} />
+          <div className="p-4 flex-1">
             {/* Breadcrumb simple */}
             <nav className="mb-4 text-sm text-gray-500">
               <Link to="/" className="hover:underline">
@@ -20,7 +38,9 @@ export default function Layout() {
               </Link>
               {pathname !== '/' && <span> / {pathname.replace('/', '')}</span>}
             </nav>
-            <Outlet />
+            <div className="max-w-6xl mx-auto">
+              <Outlet />
+            </div>
           </div>
         </main>
       </div>

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,29 +1,50 @@
 import { NavLink } from 'react-router-dom';
 
+import { useAuth } from '@/app/hooks/useAuth';
+
 const linkBase = 'block px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors';
 const linkClassName = ({ isActive }: { isActive: boolean }) =>
   isActive ? `${linkBase} bg-gray-200 font-semibold` : `${linkBase} text-gray-700`;
 
-export default function Sidebar() {
+type SidebarProps = {
+  className?: string;
+  onNavigate?: () => void;
+};
+
+const navItems = [
+  { to: '/', label: 'Dashboard', roles: ['admin', 'docente', 'padre'] },
+  { to: '/estudiantes', label: 'Estudiantes', roles: ['admin', 'docente'] },
+  { to: '/docentes', label: 'Docentes', roles: ['admin'] },
+  { to: '/cursos', label: 'Cursos', roles: ['admin'] },
+  { to: '/materias', label: 'Materias', roles: ['admin'] },
+];
+
+export default function Sidebar({ className = '', onNavigate }: SidebarProps) {
+  const { user } = useAuth();
+
+  const allowedItems = navItems.filter((item) =>
+    user ? item.roles.includes(user.role) : false,
+  );
+
+  if (!user) {
+    return null;
+  }
+
   return (
-    <aside className="w-64 h-screen sticky top-0 border-r bg-white p-4 flex flex-col gap-6">
+    <aside className={`w-64 bg-white p-4 flex flex-col gap-6 overflow-y-auto ${className}`}>
       <div className="font-bold text-xl">Académico</div>
       <nav className="space-y-1">
-        <NavLink to="/" end className={linkClassName}>
-          Dashboard
-        </NavLink>
-        <NavLink to="/estudiantes" className={linkClassName}>
-          Estudiantes
-        </NavLink>
-        <NavLink to="/docentes" className={linkClassName}>
-          Docentes
-        </NavLink>
-        <NavLink to="/cursos" className={linkClassName}>
-          Cursos
-        </NavLink>
-        <NavLink to="/materias" className={linkClassName}>
-          Materias
-        </NavLink>
+        {allowedItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.to === '/'}
+            className={linkClassName}
+            onClick={onNavigate}
+          >
+            {item.label}
+          </NavLink>
+        ))}
       </nav>
     </aside>
   );

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -1,14 +1,42 @@
 import { useAuth } from '@/app/hooks/useAuth';
 
-export default function Topbar() {
+type TopbarProps = {
+  onToggleSidebar?: () => void;
+};
+
+export default function Topbar({ onToggleSidebar }: TopbarProps) {
   const { user, logout } = useAuth();
 
   return (
-    <header className="h-14 border-b bg-white px-4 flex items-center justify-between">
-      <div className="font-semibold">Unidad Educativa Adventista Los Andes</div>
+    <header className="h-14 border-b bg-white px-4 flex items-center justify-between sticky top-0 z-30">
       <div className="flex items-center gap-3">
-        {user && <span className="text-sm text-gray-600">{user.name} • {user.role}</span>}
-        <button onClick={logout} className="text-sm px-3 py-1 rounded bg-gray-900 text-white">
+        <button
+          type="button"
+          className="lg:hidden inline-flex items-center justify-center w-9 h-9 rounded-md border border-gray-200 text-gray-600"
+          onClick={() => onToggleSidebar?.()}
+          aria-label="Abrir menú"
+        >
+          <span className="sr-only">Abrir menú</span>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-5 h-5"
+            aria-hidden
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5" />
+          </svg>
+        </button>
+        <div className="font-semibold text-sm sm:text-base">Unidad Educativa Adventista Los Andes</div>
+      </div>
+      <div className="flex items-center gap-3">
+        {user && <span className="text-xs sm:text-sm text-gray-600">{user.name} • {user.role}</span>}
+        <button
+          onClick={logout}
+          className="text-sm px-3 py-1 rounded bg-gray-900 text-white hover:bg-gray-800 transition-colors"
+        >
           Salir
         </button>
       </div>

--- a/src/app/services/courses.ts
+++ b/src/app/services/courses.ts
@@ -5,12 +5,17 @@ export const COURSES_PAGE_SIZE = 10;
 
 export async function getCourses(filters: CourseFilters) {
   const { page, search, page_size = COURSES_PAGE_SIZE } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
   const { data } = await api.get<Paginated<Course>>('/courses', {
-    params: {
-      page,
-      page_size,
-      search: search ?? '',
-    },
+    params,
   });
   return data;
 }

--- a/src/app/services/students.ts
+++ b/src/app/services/students.ts
@@ -5,12 +5,17 @@ export const STUDENTS_PAGE_SIZE = 10;
 
 export async function getStudents(filters: StudentFilters) {
   const { page, search, page_size = STUDENTS_PAGE_SIZE } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
   const { data } = await api.get<Paginated<Student>>('/students', {
-    params: {
-      page,
-      page_size,
-      search: search ?? '',
-    },
+    params,
   });
   return data;
 }

--- a/src/app/services/subjects.ts
+++ b/src/app/services/subjects.ts
@@ -5,13 +5,21 @@ export const SUBJECTS_PAGE_SIZE = 10;
 
 export async function getSubjects(filters: SubjectFilters) {
   const { page, search, page_size = SUBJECTS_PAGE_SIZE, curso_id } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
+  if (typeof curso_id === 'number') {
+    params.curso_id = curso_id;
+  }
+
   const { data } = await api.get<Paginated<Subject>>('/subjects', {
-    params: {
-      page,
-      page_size,
-      search: search ?? '',
-      curso_id,
-    },
+    params,
   });
   return data;
 }

--- a/src/app/services/teachers.ts
+++ b/src/app/services/teachers.ts
@@ -5,12 +5,17 @@ export const TEACHERS_PAGE_SIZE = 10;
 
 export async function getTeachers(filters: TeacherFilters) {
   const { page, search, page_size = TEACHERS_PAGE_SIZE } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
   const { data } = await api.get<Paginated<Teacher>>('/teachers', {
-    params: {
-      page,
-      page_size,
-      search: search ?? '',
-    },
+    params,
   });
   return data;
 }


### PR DESCRIPTION
## Summary
- avoid sending empty query params when fetching paginated resources to prevent API validation errors
- hide restricted navigation links and add a mobile drawer sidebar with overlay support
- add a responsive topbar with hamburger toggle and keep main content centered on large screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ebde5a1c8325b7fb4b9387b4e14a