### PR TITLE
Set default role to admin

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -23,8 +23,8 @@ const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
     return 'padre';
   }
 
-  console.warn(`Rol desconocido recibido: ${role}. Se usará "docente" por defecto.`);
-  return 'docente';
+  console.warn(`Rol desconocido recibido: ${role}. Se usará "admin" por defecto.`);
+  return 'admin';
 };
 
 const normalizeUser = (user: ApiUser | User): User => {


### PR DESCRIPTION
## Summary
- change the fallback role normalization to return the admin role
- update the warning message to mention the new default role

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5ee98c9548325be71a1025c68d08d