### PR TITLE
Add people and user management UI

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -15,8 +15,10 @@ const navItems = [
   { to: '/', label: 'Dashboard', roles: ['admin', 'docente', 'padre'] },
   { to: '/estudiantes', label: 'Estudiantes', roles: ['admin', 'docente'] },
   { to: '/docentes', label: 'Docentes', roles: ['admin'] },
+  { to: '/personas', label: 'Personas', roles: ['admin'] },
   { to: '/cursos', label: 'Cursos', roles: ['admin'] },
   { to: '/materias', label: 'Materias', roles: ['admin'] },
+  { to: '/usuarios', label: 'Usuarios', roles: ['admin'] },
 ];
 
 export default function Sidebar({ className = '', onNavigate }: SidebarProps) {

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -14,6 +14,10 @@ import SubjectForm from '@/pages/subjects/SubjectForm';
 import SubjectsList from '@/pages/subjects/SubjectsList';
 import TeacherForm from '@/pages/teachers/TeacherForm';
 import TeachersList from '@/pages/teachers/TeachersList';
+import PeopleList from '@/pages/people/PeopleList';
+import PersonForm from '@/pages/people/PersonForm';
+import UsersList from '@/pages/users/UsersList';
+import UserForm from '@/pages/users/UserForm';
 
 export default function AppRouter() {
   const { isAuthenticated } = useAuth();
@@ -36,12 +40,18 @@ export default function AppRouter() {
             <Route path="docentes" element={<TeachersList />} />
             <Route path="docentes/nuevo" element={<TeacherForm />} />
             <Route path="docentes/:teacherId/editar" element={<TeacherForm />} />
+            <Route path="personas" element={<PeopleList />} />
+            <Route path="personas/nuevo" element={<PersonForm />} />
+            <Route path="personas/:personId/editar" element={<PersonForm />} />
             <Route path="cursos" element={<CoursesList />} />
             <Route path="cursos/nuevo" element={<CourseForm />} />
             <Route path="cursos/:courseId/editar" element={<CourseForm />} />
             <Route path="materias" element={<SubjectsList />} />
             <Route path="materias/nuevo" element={<SubjectForm />} />
             <Route path="materias/:subjectId/editar" element={<SubjectForm />} />
+            <Route path="usuarios" element={<UsersList />} />
+            <Route path="usuarios/nuevo" element={<UserForm />} />
+            <Route path="usuarios/:userId/editar" element={<UserForm />} />
           </Route>
         </Route>
       </Route>

--- a/src/app/services/people.ts
+++ b/src/app/services/people.ts
@@ -1,0 +1,50 @@
+import api from '@/app/services/api';
+import type { Paginated, Person, PersonFilters, PersonPayload } from '@/app/types';
+
+export const PEOPLE_PAGE_SIZE = 10;
+
+export async function getPeople(filters: PersonFilters) {
+  const { page, search, page_size = PEOPLE_PAGE_SIZE } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
+  const { data } = await api.get<Paginated<Person>>('/people', {
+    params,
+  });
+  return data;
+}
+
+export async function getPerson(id: number) {
+  const { data } = await api.get<Person>(`/people/${id}`);
+  return data;
+}
+
+export async function createPerson(payload: PersonPayload) {
+  const { data } = await api.post<Person>('/people', payload);
+  return data;
+}
+
+export async function updatePerson(id: number, payload: PersonPayload) {
+  const { data } = await api.put<Person>(`/people/${id}`, payload);
+  return data;
+}
+
+export async function deletePerson(id: number) {
+  await api.delete(`/people/${id}`);
+}
+
+export async function getAllPeople() {
+  const { data } = await api.get<Paginated<Person>>('/people', {
+    params: {
+      page: 1,
+      page_size: 1000,
+    },
+  });
+  return data.items;
+}

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -1,0 +1,87 @@
+import api from '@/app/services/api';
+import type {
+  ApiManagedUser,
+  ManagedUser,
+  Paginated,
+  UserFilters,
+  UserPayload,
+} from '@/app/types';
+
+export const USERS_PAGE_SIZE = 10;
+
+const normalizeRole = (role: ApiManagedUser['role'] | ManagedUser['role'] | string): ManagedUser['role'] => {
+  const normalized = `${role}`.toLowerCase();
+  if (normalized === 'admin' || normalized === 'administrador') {
+    return 'admin';
+  }
+  if (normalized === 'docente') {
+    return 'docente';
+  }
+  if (normalized === 'padre') {
+    return 'padre';
+  }
+  console.warn(`Rol desconocido recibido: ${role}. Se usará "admin" por defecto.`);
+  return 'admin';
+};
+
+const mapUser = (user: ApiManagedUser): ManagedUser => ({
+  ...user,
+  role: normalizeRole(user.role),
+});
+
+export async function getUsers(filters: UserFilters) {
+  const { page, search, page_size = USERS_PAGE_SIZE, role } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
+  if (role) {
+    params.role = role;
+  }
+
+  const { data } = await api.get<Paginated<ApiManagedUser>>('/users', {
+    params,
+  });
+  return {
+    ...data,
+    items: data.items.map(mapUser),
+  };
+}
+
+export async function getUser(id: number) {
+  const { data } = await api.get<ApiManagedUser>(`/users/${id}`);
+  return mapUser(data);
+}
+
+export async function createUser(payload: UserPayload) {
+  const { data } = await api.post<ApiManagedUser>('/users', payload);
+  return mapUser(data);
+}
+
+export async function updateUser(id: number, payload: UserPayload) {
+  const body: UserPayload = {
+    username: payload.username,
+    role: payload.role,
+    persona_id: payload.persona_id,
+  };
+
+  if (payload.email) {
+    body.email = payload.email;
+  }
+
+  if (payload.password) {
+    body.password = payload.password;
+  }
+
+  const { data } = await api.put<ApiManagedUser>(`/users/${id}`, body);
+  return mapUser(data);
+}
+
+export async function deleteUser(id: number) {
+  await api.delete(`/users/${id}`);
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -56,6 +56,27 @@ export interface StudentPayload {
 
 export type StudentFilters = PaginationFilters;
 
+export interface Person {
+  id: number;
+  ci: string | null;
+  nombres: string;
+  apellidos: string;
+  direccion?: string | null;
+  telefono?: string | null;
+  correo?: string | null;
+}
+
+export interface PersonPayload {
+  ci: string;
+  nombres: string;
+  apellidos: string;
+  direccion?: string;
+  telefono?: string;
+  correo?: string;
+}
+
+export type PersonFilters = PaginationFilters;
+
 export interface TeacherSubject {
   id: number;
   nombre: string;
@@ -112,4 +133,30 @@ export interface SubjectPayload {
 
 export interface SubjectFilters extends PaginationFilters {
   curso_id?: number;
+}
+
+export interface ManagedUser {
+  id: number;
+  username: string;
+  name?: string | null;
+  email?: string | null;
+  role: Role;
+  persona?: Person | null;
+  persona_id?: number | null;
+}
+
+export interface ApiManagedUser extends Omit<ManagedUser, 'role'> {
+  role: ApiRole;
+}
+
+export interface UserPayload {
+  username: string;
+  role: Role;
+  persona_id: number;
+  email?: string;
+  password?: string;
+}
+
+export interface UserFilters extends PaginationFilters {
+  role?: Role;
 }

--- a/src/pages/people/PeopleList.tsx
+++ b/src/pages/people/PeopleList.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+
+import { deletePerson, getPeople, PEOPLE_PAGE_SIZE } from '@/app/services/people';
+import type { Person } from '@/app/types';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default function PeopleList() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ['people', page, debouncedSearch],
+    queryFn: async () =>
+      getPeople({
+        page,
+        search: debouncedSearch || undefined,
+        page_size: PEOPLE_PAGE_SIZE,
+      }),
+    placeholderData: (previousData) => previousData,
+  });
+
+  const people: Person[] = data?.items ?? [];
+  const pageSize = data?.page_size ?? PEOPLE_PAGE_SIZE;
+  const isEmpty = !isLoading && !isError && people.length === 0;
+  const disablePrevious = page === 1 || isFetching;
+  const disableNext = people.length < pageSize || isFetching;
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => deletePerson(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['people'] });
+    },
+  });
+
+  const handleDelete = (id: number) => {
+    const confirmed = window.confirm('¿Deseas eliminar esta persona?');
+    if (!confirmed) {
+      return;
+    }
+    deleteMutation.mutate(id);
+  };
+
+  const formatFullName = (person: Person) => `${person.apellidos} ${person.nombres}`.trim();
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-semibold">Personas</h1>
+        <Link to="/personas/nuevo" className="px-3 py-2 rounded bg-gray-900 text-white">
+          Nueva persona
+        </Link>
+      </div>
+
+      <div className="mb-3">
+        <label className="block text-sm font-medium text-gray-600 mb-1" htmlFor="people-search">
+          Buscar
+        </label>
+        <input
+          id="people-search"
+          placeholder="Buscar por nombre o CI…"
+          className="border rounded px-3 py-2 w-full"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      </div>
+
+      {isLoading && <p>Cargando…</p>}
+      {isError && <p className="text-red-600">Error al cargar las personas.</p>}
+      {isFetching && !isLoading && <p className="text-sm text-gray-500">Actualizando…</p>}
+      {isEmpty && <p className="text-sm text-gray-500">No se encontraron personas.</p>}
+
+      {people.length > 0 && (
+        <>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">CI</th>
+                <th>Nombre</th>
+                <th>Teléfono</th>
+                <th>Correo</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {people.map((person) => (
+                <tr key={person.id} className="border-b last:border-0">
+                  <td className="py-2">{person.ci || '-'}</td>
+                  <td>{formatFullName(person)}</td>
+                  <td>{person.telefono || '-'}</td>
+                  <td>{person.correo || '-'}</td>
+                  <td>
+                    <div className="flex gap-2">
+                      <Link
+                        to={`/personas/${person.id}/editar`}
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        Editar
+                      </Link>
+                      <button
+                        type="button"
+                        className="text-sm text-red-600 hover:underline"
+                        onClick={() => handleDelete(person.id)}
+                        disabled={deleteMutation.isPending}
+                      >
+                        Eliminar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {deleteMutation.isError && (
+            <p className="text-sm text-red-600 mt-2">No se pudo eliminar la persona.</p>
+          )}
+
+          <div className="flex items-center gap-2 justify-end mt-4">
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              disabled={disablePrevious}
+            >
+              Anterior
+            </button>
+            <span>Página {page}</span>
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => current + 1)}
+              disabled={disableNext}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/people/PersonForm.tsx
+++ b/src/pages/people/PersonForm.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { FormEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { z } from 'zod';
+
+import { createPerson, getPerson, updatePerson } from '@/app/services/people';
+import type { PersonPayload } from '@/app/types';
+
+const personSchema = z.object({
+  ci: z.string().min(5, 'La cédula debe tener al menos 5 caracteres').max(20, 'Máximo 20 caracteres'),
+  nombres: z.string().min(2, 'Ingresa los nombres'),
+  apellidos: z.string().min(2, 'Ingresa los apellidos'),
+  direccion: z.string().min(3, 'Ingresa la dirección').optional(),
+  telefono: z.string().min(6, 'Ingresa un teléfono válido').max(20, 'Máximo 20 caracteres').optional(),
+  correo: z.string().email('Ingresa un correo válido').optional(),
+});
+
+type PersonFormState = {
+  ci: string;
+  nombres: string;
+  apellidos: string;
+  direccion: string;
+  telefono: string;
+  correo: string;
+};
+
+type FieldErrors = Partial<Record<keyof PersonFormState, string>>;
+
+const initialValues: PersonFormState = {
+  ci: '',
+  nombres: '',
+  apellidos: '',
+  direccion: '',
+  telefono: '',
+  correo: '',
+};
+
+export default function PersonForm() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { personId } = useParams();
+  const isEditing = Boolean(personId);
+  const [form, setForm] = useState<PersonFormState>(initialValues);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState('');
+
+  const personQuery = useQuery({
+    queryKey: ['person', personId],
+    queryFn: async () => (personId ? getPerson(Number(personId)) : null),
+    enabled: isEditing,
+  });
+
+  useEffect(() => {
+    if (personQuery.data) {
+      setForm({
+        ci: personQuery.data.ci ?? '',
+        nombres: personQuery.data.nombres,
+        apellidos: personQuery.data.apellidos,
+        direccion: personQuery.data.direccion ?? '',
+        telefono: personQuery.data.telefono ?? '',
+        correo: personQuery.data.correo ?? '',
+      });
+    }
+  }, [personQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: PersonPayload) =>
+      personId ? updatePerson(Number(personId), payload) : createPerson(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['people'] });
+      if (personId) {
+        queryClient.invalidateQueries({ queryKey: ['person', personId] });
+      }
+      navigate('/personas');
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? // @ts-expect-error Axios style error shape
+            error.response?.data?.detail ?? 'No se pudo guardar'
+          : 'No se pudo guardar';
+      setSubmitError(typeof message === 'string' ? message : 'No se pudo guardar');
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError('');
+
+    const result = personSchema.safeParse({
+      ci: form.ci.trim(),
+      nombres: form.nombres.trim(),
+      apellidos: form.apellidos.trim(),
+      direccion: form.direccion.trim() || undefined,
+      telefono: form.telefono.trim() || undefined,
+      correo: form.correo.trim() || undefined,
+    });
+
+    if (!result.success) {
+      const newErrors: FieldErrors = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0];
+        if (typeof field === 'string' && !(field in newErrors)) {
+          newErrors[field as keyof PersonFormState] = issue.message;
+        }
+      }
+      setFieldErrors(newErrors);
+      return;
+    }
+
+    setFieldErrors({});
+    mutation.mutate(result.data);
+  };
+
+  const updateField = (field: keyof PersonFormState) => (value: string) => {
+    setFieldErrors((previous) => {
+      if (!previous[field]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[field];
+      return next;
+    });
+    setForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  if (isEditing && personQuery.isLoading) {
+    return <p>Cargando persona…</p>;
+  }
+
+  if (isEditing && personQuery.isError) {
+    return <p className="text-red-600">No se pudo cargar la información de la persona.</p>;
+  }
+
+  const title = isEditing ? 'Editar persona' : 'Nueva persona';
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4 max-w-2xl">
+      <h1 className="text-lg font-semibold mb-4">{title}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-ci">
+              CI
+            </label>
+            <input
+              id="person-ci"
+              className="w-full border rounded px-3 py-2"
+              value={form.ci}
+              onChange={(event) => updateField('ci')(event.target.value)}
+            />
+            {fieldErrors.ci && <p className="text-sm text-red-600 mt-1">{fieldErrors.ci}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-telefono">
+              Teléfono
+            </label>
+            <input
+              id="person-telefono"
+              className="w-full border rounded px-3 py-2"
+              value={form.telefono}
+              onChange={(event) => updateField('telefono')(event.target.value)}
+            />
+            {fieldErrors.telefono && <p className="text-sm text-red-600 mt-1">{fieldErrors.telefono}</p>}
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-nombres">
+              Nombres
+            </label>
+            <input
+              id="person-nombres"
+              className="w-full border rounded px-3 py-2"
+              value={form.nombres}
+              onChange={(event) => updateField('nombres')(event.target.value)}
+            />
+            {fieldErrors.nombres && <p className="text-sm text-red-600 mt-1">{fieldErrors.nombres}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-apellidos">
+              Apellidos
+            </label>
+            <input
+              id="person-apellidos"
+              className="w-full border rounded px-3 py-2"
+              value={form.apellidos}
+              onChange={(event) => updateField('apellidos')(event.target.value)}
+            />
+            {fieldErrors.apellidos && <p className="text-sm text-red-600 mt-1">{fieldErrors.apellidos}</p>}
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-correo">
+              Correo electrónico
+            </label>
+            <input
+              id="person-correo"
+              className="w-full border rounded px-3 py-2"
+              value={form.correo}
+              onChange={(event) => updateField('correo')(event.target.value)}
+            />
+            {fieldErrors.correo && <p className="text-sm text-red-600 mt-1">{fieldErrors.correo}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="person-direccion">
+              Dirección
+            </label>
+            <input
+              id="person-direccion"
+              className="w-full border rounded px-3 py-2"
+              value={form.direccion}
+              onChange={(event) => updateField('direccion')(event.target.value)}
+            />
+            {fieldErrors.direccion && <p className="text-sm text-red-600 mt-1">{fieldErrors.direccion}</p>}
+          </div>
+        </div>
+        {submitError && <p className="text-red-600 text-sm">{submitError}</p>}
+        <div className="flex gap-2 justify-end">
+          <button type="button" className="px-3 py-2 border rounded" onClick={() => navigate(-1)}>
+            Cancelar
+          </button>
+          <button className="px-3 py-2 rounded bg-gray-900 text-white disabled:opacity-50" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/users/UserForm.tsx
+++ b/src/pages/users/UserForm.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { FormEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { z } from 'zod';
+
+import { getAllPeople } from '@/app/services/people';
+import { createUser, getUser, updateUser } from '@/app/services/users';
+import type { Person, Role, UserPayload } from '@/app/types';
+
+const userSchema = z.object({
+  username: z.string().min(3, 'Ingresa el nombre de usuario'),
+  role: z.enum(['admin', 'docente', 'padre']),
+  persona_id: z.number().int('Selecciona una persona').min(1, 'Selecciona una persona'),
+  email: z.string().email('Ingresa un correo válido').optional(),
+  password: z.string().min(6, 'La contraseña debe tener al menos 6 caracteres').optional(),
+});
+
+type UserFormState = {
+  username: string;
+  role: Role;
+  personaId: string;
+  email: string;
+  password: string;
+};
+
+type FieldErrors = Partial<{
+  username: string;
+  role: string;
+  persona_id: string;
+  email: string;
+  password: string;
+}>;
+
+const initialValues: UserFormState = {
+  username: '',
+  role: 'docente',
+  personaId: '',
+  email: '',
+  password: '',
+};
+
+const roleLabels: Record<Role, string> = {
+  admin: 'Administrador',
+  docente: 'Docente',
+  padre: 'Padre',
+};
+
+export default function UserForm() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { userId } = useParams();
+  const isEditing = Boolean(userId);
+  const [form, setForm] = useState<UserFormState>(initialValues);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState('');
+
+  const peopleQuery = useQuery({
+    queryKey: ['people', 'all'],
+    queryFn: async () => getAllPeople(),
+  });
+
+  const userQuery = useQuery({
+    queryKey: ['user', userId],
+    queryFn: async () => (userId ? getUser(Number(userId)) : null),
+    enabled: isEditing,
+  });
+
+  useEffect(() => {
+    if (userQuery.data) {
+      setForm({
+        username: userQuery.data.username,
+        role: userQuery.data.role,
+        personaId: userQuery.data.persona?.id?.toString() ?? userQuery.data.persona_id?.toString() ?? '',
+        email: userQuery.data.email ?? '',
+        password: '',
+      });
+    }
+  }, [userQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: UserPayload) =>
+      userId ? updateUser(Number(userId), payload) : createUser(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      if (userId) {
+        queryClient.invalidateQueries({ queryKey: ['user', userId] });
+      }
+      navigate('/usuarios');
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? // @ts-expect-error Axios style error shape
+            error.response?.data?.detail ?? 'No se pudo guardar'
+          : 'No se pudo guardar';
+      setSubmitError(typeof message === 'string' ? message : 'No se pudo guardar');
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError('');
+
+    const personaIdNumber = Number(form.personaId);
+
+    const result = userSchema.safeParse({
+      username: form.username.trim(),
+      role: form.role,
+      persona_id: Number.isNaN(personaIdNumber) ? 0 : personaIdNumber,
+      email: form.email.trim() || undefined,
+      password: form.password.trim() || undefined,
+    });
+
+    if (!result.success) {
+      const newErrors: FieldErrors = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0];
+        if (typeof field === 'string' && !(field in newErrors)) {
+          newErrors[field as keyof FieldErrors] = issue.message;
+        }
+      }
+      setFieldErrors(newErrors);
+      return;
+    }
+
+    if (!isEditing && !result.data.password) {
+      setFieldErrors({ password: 'Ingresa una contraseña' });
+      return;
+    }
+
+    setFieldErrors({});
+    mutation.mutate(result.data);
+  };
+
+  const updateField = <TField extends keyof UserFormState>(field: TField) => (value: UserFormState[TField]) => {
+    setFieldErrors((previous) => {
+      const targetField = field === 'personaId' ? 'persona_id' : field;
+      if (!previous[targetField as keyof FieldErrors]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[targetField as keyof FieldErrors];
+      return next;
+    });
+    setForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  if (isEditing && userQuery.isLoading) {
+    return <p>Cargando usuario…</p>;
+  }
+
+  if (isEditing && userQuery.isError) {
+    return <p className="text-red-600">No se pudo cargar la información del usuario.</p>;
+  }
+
+  const title = isEditing ? 'Editar usuario' : 'Nuevo usuario';
+
+  const peopleOptions = useMemo<Person[]>(() => {
+    if (!peopleQuery.data) {
+      return [];
+    }
+    return [...peopleQuery.data].sort((a, b) => {
+      const nameA = `${a.apellidos} ${a.nombres}`.trim().toLowerCase();
+      const nameB = `${b.apellidos} ${b.nombres}`.trim().toLowerCase();
+      if (nameA < nameB) {
+        return -1;
+      }
+      if (nameA > nameB) {
+        return 1;
+      }
+      return 0;
+    });
+  }, [peopleQuery.data]);
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4 max-w-2xl">
+      <h1 className="text-lg font-semibold mb-4">{title}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="user-username">
+              Usuario
+            </label>
+            <input
+              id="user-username"
+              className="w-full border rounded px-3 py-2"
+              value={form.username}
+              onChange={(event) => updateField('username')(event.target.value)}
+            />
+            {fieldErrors.username && <p className="text-sm text-red-600 mt-1">{fieldErrors.username}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="user-role">
+              Rol
+            </label>
+            <select
+              id="user-role"
+              className="w-full border rounded px-3 py-2"
+              value={form.role}
+              onChange={(event) => updateField('role')(event.target.value as Role)}
+            >
+              {Object.entries(roleLabels).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            {fieldErrors.role && <p className="text-sm text-red-600 mt-1">{fieldErrors.role}</p>}
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600" htmlFor="user-persona">
+            Persona vinculada
+          </label>
+          <select
+            id="user-persona"
+            className="w-full border rounded px-3 py-2"
+            value={form.personaId}
+            onChange={(event) => updateField('personaId')(event.target.value)}
+            disabled={peopleQuery.isLoading}
+          >
+            <option value="">Selecciona una persona…</option>
+            {peopleOptions.map((person) => (
+              <option key={person.id} value={person.id}>
+                {`${person.apellidos} ${person.nombres}`.trim()} {person.ci ? `• ${person.ci}` : ''}
+              </option>
+            ))}
+          </select>
+          {peopleQuery.isError && (
+            <p className="text-sm text-red-600 mt-1">No se pudieron cargar las personas.</p>
+          )}
+          {fieldErrors.persona_id && (
+            <p className="text-sm text-red-600 mt-1">{fieldErrors.persona_id}</p>
+          )}
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="user-email">
+              Correo electrónico
+            </label>
+            <input
+              id="user-email"
+              className="w-full border rounded px-3 py-2"
+              value={form.email}
+              onChange={(event) => updateField('email')(event.target.value)}
+            />
+            {fieldErrors.email && <p className="text-sm text-red-600 mt-1">{fieldErrors.email}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="user-password">
+              Contraseña {isEditing && <span className="text-xs text-gray-500">(opcional)</span>}
+            </label>
+            <input
+              type="password"
+              id="user-password"
+              className="w-full border rounded px-3 py-2"
+              value={form.password}
+              onChange={(event) => updateField('password')(event.target.value)}
+              placeholder={isEditing ? 'Dejar en blanco para mantener' : ''}
+            />
+            {fieldErrors.password && <p className="text-sm text-red-600 mt-1">{fieldErrors.password}</p>}
+          </div>
+        </div>
+        {submitError && <p className="text-red-600 text-sm">{submitError}</p>}
+        <div className="flex gap-2 justify-end">
+          <button type="button" className="px-3 py-2 border rounded" onClick={() => navigate(-1)}>
+            Cancelar
+          </button>
+          <button className="px-3 py-2 rounded bg-gray-900 text-white disabled:opacity-50" disabled={mutation.isPending}>
+            {mutation.isPending ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/users/UsersList.tsx
+++ b/src/pages/users/UsersList.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+
+import { deleteUser, getUsers, USERS_PAGE_SIZE } from '@/app/services/users';
+import type { ManagedUser, Role } from '@/app/types';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const roleLabels: Record<Role, string> = {
+  admin: 'Administrador',
+  docente: 'Docente',
+  padre: 'Padre',
+};
+
+type RoleFilter = Role | 'all';
+
+export default function UsersList() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilter>('all');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ['users', page, debouncedSearch, roleFilter],
+    queryFn: async () =>
+      getUsers({
+        page,
+        search: debouncedSearch || undefined,
+        page_size: USERS_PAGE_SIZE,
+        role: roleFilter === 'all' ? undefined : roleFilter,
+      }),
+    placeholderData: (previousData) => previousData,
+  });
+
+  const users: ManagedUser[] = useMemo(() => data?.items ?? [], [data?.items]);
+  const pageSize = data?.page_size ?? USERS_PAGE_SIZE;
+  const isEmpty = !isLoading && !isError && users.length === 0;
+  const disablePrevious = page === 1 || isFetching;
+  const disableNext = users.length < pageSize || isFetching;
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => deleteUser(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+    },
+  });
+
+  const handleDelete = (id: number) => {
+    const confirmed = window.confirm('¿Deseas eliminar este usuario?');
+    if (!confirmed) {
+      return;
+    }
+    deleteMutation.mutate(id);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
+        <h1 className="text-lg font-semibold">Usuarios</h1>
+        <Link to="/usuarios/nuevo" className="px-3 py-2 rounded bg-gray-900 text-white">
+          Nuevo usuario
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
+        <div className="md:col-span-2">
+          <label className="block text-sm font-medium text-gray-600 mb-1" htmlFor="users-search">
+            Buscar
+          </label>
+          <input
+            id="users-search"
+            placeholder="Buscar por usuario o correo…"
+            className="border rounded px-3 py-2 w-full"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-600 mb-1" htmlFor="users-role-filter">
+            Rol
+          </label>
+          <select
+            id="users-role-filter"
+            className="border rounded px-3 py-2 w-full"
+            value={roleFilter}
+            onChange={(event) => {
+              setRoleFilter(event.target.value as RoleFilter);
+              setPage(1);
+            }}
+          >
+            <option value="all">Todos</option>
+            <option value="admin">Administrador</option>
+            <option value="docente">Docente</option>
+            <option value="padre">Padre</option>
+          </select>
+        </div>
+      </div>
+
+      {isLoading && <p>Cargando…</p>}
+      {isError && <p className="text-red-600">Error al cargar los usuarios.</p>}
+      {isFetching && !isLoading && <p className="text-sm text-gray-500">Actualizando…</p>}
+      {isEmpty && <p className="text-sm text-gray-500">No se encontraron usuarios.</p>}
+
+      {users.length > 0 && (
+        <>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">Usuario</th>
+                <th>Rol</th>
+                <th>Persona</th>
+                <th>Correo</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr key={user.id} className="border-b last:border-0">
+                  <td className="py-2">{user.username}</td>
+                  <td>{roleLabels[user.role]}</td>
+                  <td>
+                    {user.persona
+                      ? `${user.persona.apellidos} ${user.persona.nombres}`.trim()
+                      : user.name ?? '-'}
+                  </td>
+                  <td>{user.email || '-'}</td>
+                  <td>
+                    <div className="flex gap-2">
+                      <Link
+                        to={`/usuarios/${user.id}/editar`}
+                        className="text-sm text-blue-600 hover:underline"
+                      >
+                        Editar
+                      </Link>
+                      <button
+                        type="button"
+                        className="text-sm text-red-600 hover:underline"
+                        onClick={() => handleDelete(user.id)}
+                        disabled={deleteMutation.isPending}
+                      >
+                        Eliminar
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {deleteMutation.isError && (
+            <p className="text-sm text-red-600 mt-2">No se pudo eliminar el usuario.</p>
+          )}
+
+          <div className="flex items-center gap-2 justify-end mt-4">
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              disabled={disablePrevious}
+            >
+              Anterior
+            </button>
+            <span>Página {page}</span>
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => current + 1)}
+              disabled={disableNext}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared types and API clients for personas and usuarios
- build list and form screens to manage personas and usuarios
- expose new admin navigation entries and routes for the management pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ef97163c8325ab4fbeea8b14ab90