### PR TITLE
Adjust people service to personas API

### DIFF
--- a/src/app/services/people.ts
+++ b/src/app/services/people.ts
@@ -1,7 +1,49 @@
 import api from '@/app/services/api';
-import type { Paginated, Person, PersonFilters, PersonPayload } from '@/app/types';
+import type { ApiPerson, Paginated, Person, PersonFilters, PersonPayload } from '@/app/types';
 
 export const PEOPLE_PAGE_SIZE = 10;
+
+const PEOPLE_ENDPOINT = '/personas';
+
+const mapPerson = (person: ApiPerson): Person => {
+  const celular = person.celular ?? null;
+  const ciNumero = person.ci_numero ?? null;
+
+  return {
+    id: person.id,
+    nombres: person.nombres,
+    apellidos: person.apellidos,
+    direccion: person.direccion ?? null,
+    telefono: celular,
+    correo: person.correo ?? null,
+    ci: ciNumero,
+    sexo: person.sexo ?? null,
+    fecha_nacimiento: person.fecha_nacimiento ?? null,
+    celular,
+    ci_numero: ciNumero,
+    ci_complemento: person.ci_complemento ?? null,
+    ci_expedicion: person.ci_expedicion ?? null,
+  };
+};
+
+const mapPayloadToApi = (payload: PersonPayload) => {
+  const body: Record<string, unknown> = {
+    nombres: payload.nombres,
+    apellidos: payload.apellidos,
+    direccion: payload.direccion,
+    celular: payload.celular ?? payload.telefono,
+    correo: payload.correo,
+    sexo: payload.sexo,
+    fecha_nacimiento: payload.fecha_nacimiento,
+    ci_numero: payload.ci_numero ?? payload.ci,
+    ci_complemento: payload.ci_complemento,
+    ci_expedicion: payload.ci_expedicion,
+  };
+
+  return Object.fromEntries(
+    Object.entries(body).filter(([, value]) => value !== undefined && value !== null && value !== ''),
+  ) as Record<string, unknown>;
+};
 
 export async function getPeople(filters: PersonFilters) {
   const { page, search, page_size = PEOPLE_PAGE_SIZE } = filters;
@@ -14,37 +56,42 @@ export async function getPeople(filters: PersonFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Person>>('/people', {
+  const { data } = await api.get<Paginated<ApiPerson>>(PEOPLE_ENDPOINT, {
     params,
   });
-  return data;
+  return {
+    ...data,
+    items: data.items.map(mapPerson),
+  };
 }
 
 export async function getPerson(id: number) {
-  const { data } = await api.get<Person>(`/people/${id}`);
-  return data;
+  const { data } = await api.get<ApiPerson>(`${PEOPLE_ENDPOINT}/${id}`);
+  return mapPerson(data);
 }
 
 export async function createPerson(payload: PersonPayload) {
-  const { data } = await api.post<Person>('/people', payload);
-  return data;
+  const body = mapPayloadToApi(payload);
+  const { data } = await api.post<ApiPerson>(PEOPLE_ENDPOINT, body);
+  return mapPerson(data);
 }
 
 export async function updatePerson(id: number, payload: PersonPayload) {
-  const { data } = await api.put<Person>(`/people/${id}`, payload);
-  return data;
+  const body = mapPayloadToApi(payload);
+  const { data } = await api.put<ApiPerson>(`${PEOPLE_ENDPOINT}/${id}`, body);
+  return mapPerson(data);
 }
 
 export async function deletePerson(id: number) {
-  await api.delete(`/people/${id}`);
+  await api.delete(`${PEOPLE_ENDPOINT}/${id}`);
 }
 
 export async function getAllPeople() {
-  const { data } = await api.get<Paginated<Person>>('/people', {
+  const { data } = await api.get<Paginated<ApiPerson>>(PEOPLE_ENDPOINT, {
     params: {
       page: 1,
       page_size: 1000,
     },
   });
-  return data.items;
+  return data.items.map(mapPerson);
 }

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -56,14 +56,34 @@ export interface StudentPayload {
 
 export type StudentFilters = PaginationFilters;
 
+export interface ApiPerson {
+  id: number;
+  nombres: string;
+  apellidos: string;
+  sexo?: string | null;
+  fecha_nacimiento?: string | null;
+  celular?: string | null;
+  direccion?: string | null;
+  ci_numero?: string | null;
+  ci_complemento?: string | null;
+  ci_expedicion?: string | null;
+  correo?: string | null;
+}
+
 export interface Person {
   id: number;
-  ci: string | null;
   nombres: string;
   apellidos: string;
   direccion?: string | null;
   telefono?: string | null;
   correo?: string | null;
+  ci?: string | null;
+  sexo?: string | null;
+  fecha_nacimiento?: string | null;
+  celular?: string | null;
+  ci_numero?: string | null;
+  ci_complemento?: string | null;
+  ci_expedicion?: string | null;
 }
 
 export interface PersonPayload {
@@ -73,6 +93,12 @@ export interface PersonPayload {
   direccion?: string;
   telefono?: string;
   correo?: string;
+  sexo?: string;
+  fecha_nacimiento?: string;
+  ci_complemento?: string;
+  ci_expedicion?: string;
+  ci_numero?: string;
+  celular?: string;
 }
 
 export type PersonFilters = PaginationFilters;


### PR DESCRIPTION
## Summary
- add ApiPerson type information and extend the Person payload to cover backend fields
- map people service requests/responses to the personas endpoints and normalize data for the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f447130083259af3ba012628560b