### PR TITLE
Align frontend services with backend API routes

### DIFF
--- a/src/app/services/courses.ts
+++ b/src/app/services/courses.ts
@@ -3,6 +3,8 @@ import type { Course, CourseFilters, CoursePayload, Paginated } from '@/app/type
 
 export const COURSES_PAGE_SIZE = 10;
 
+const COURSES_ENDPOINT = '/cursos';
+
 export async function getCourses(filters: CourseFilters) {
   const { page, search, page_size = COURSES_PAGE_SIZE } = filters;
   const params: Record<string, unknown> = {
@@ -14,33 +16,33 @@ export async function getCourses(filters: CourseFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Course>>('/courses', {
+  const { data } = await api.get<Paginated<Course>>(COURSES_ENDPOINT, {
     params,
   });
   return data;
 }
 
 export async function getCourse(id: number) {
-  const { data } = await api.get<Course>(`/courses/${id}`);
+  const { data } = await api.get<Course>(`${COURSES_ENDPOINT}/${id}`);
   return data;
 }
 
 export async function createCourse(payload: CoursePayload) {
-  const { data } = await api.post<Course>('/courses', payload);
+  const { data } = await api.post<Course>(COURSES_ENDPOINT, payload);
   return data;
 }
 
 export async function updateCourse(id: number, payload: CoursePayload) {
-  const { data } = await api.put<Course>(`/courses/${id}`, payload);
+  const { data } = await api.put<Course>(`${COURSES_ENDPOINT}/${id}`, payload);
   return data;
 }
 
 export async function deleteCourse(id: number) {
-  await api.delete(`/courses/${id}`);
+  await api.delete(`${COURSES_ENDPOINT}/${id}`);
 }
 
 export async function getAllCourses() {
-  const { data } = await api.get<Paginated<Course>>('/courses', {
+  const { data } = await api.get<Paginated<Course>>(COURSES_ENDPOINT, {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/students.ts
+++ b/src/app/services/students.ts
@@ -3,6 +3,8 @@ import type { Paginated, Student, StudentFilters, StudentPayload } from '@/app/t
 
 export const STUDENTS_PAGE_SIZE = 10;
 
+const STUDENTS_ENDPOINT = '/estudiantes';
+
 export async function getStudents(filters: StudentFilters) {
   const { page, search, page_size = STUDENTS_PAGE_SIZE } = filters;
   const params: Record<string, unknown> = {
@@ -14,27 +16,27 @@ export async function getStudents(filters: StudentFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Student>>('/students', {
+  const { data } = await api.get<Paginated<Student>>(STUDENTS_ENDPOINT, {
     params,
   });
   return data;
 }
 
 export async function createStudent(payload: StudentPayload) {
-  const { data } = await api.post<Student>('/students', payload);
+  const { data } = await api.post<Student>(STUDENTS_ENDPOINT, payload);
   return data;
 }
 
 export async function getStudent(id: number) {
-  const { data } = await api.get<Student>(`/students/${id}`);
+  const { data } = await api.get<Student>(`${STUDENTS_ENDPOINT}/${id}`);
   return data;
 }
 
 export async function updateStudent(id: number, payload: StudentPayload) {
-  const { data } = await api.put<Student>(`/students/${id}`, payload);
+  const { data } = await api.put<Student>(`${STUDENTS_ENDPOINT}/${id}`, payload);
   return data;
 }
 
 export async function deleteStudent(id: number) {
-  await api.delete(`/students/${id}`);
+  await api.delete(`${STUDENTS_ENDPOINT}/${id}`);
 }

--- a/src/app/services/subjects.ts
+++ b/src/app/services/subjects.ts
@@ -3,6 +3,8 @@ import type { Paginated, Subject, SubjectFilters, SubjectPayload } from '@/app/t
 
 export const SUBJECTS_PAGE_SIZE = 10;
 
+const SUBJECTS_ENDPOINT = '/materias';
+
 export async function getSubjects(filters: SubjectFilters) {
   const { page, search, page_size = SUBJECTS_PAGE_SIZE, curso_id } = filters;
   const params: Record<string, unknown> = {
@@ -18,33 +20,33 @@ export async function getSubjects(filters: SubjectFilters) {
     params.curso_id = curso_id;
   }
 
-  const { data } = await api.get<Paginated<Subject>>('/subjects', {
+  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
     params,
   });
   return data;
 }
 
 export async function getSubject(id: number) {
-  const { data } = await api.get<Subject>(`/subjects/${id}`);
+  const { data } = await api.get<Subject>(`${SUBJECTS_ENDPOINT}/${id}`);
   return data;
 }
 
 export async function createSubject(payload: SubjectPayload) {
-  const { data } = await api.post<Subject>('/subjects', payload);
+  const { data } = await api.post<Subject>(SUBJECTS_ENDPOINT, payload);
   return data;
 }
 
 export async function updateSubject(id: number, payload: SubjectPayload) {
-  const { data } = await api.put<Subject>(`/subjects/${id}`, payload);
+  const { data } = await api.put<Subject>(`${SUBJECTS_ENDPOINT}/${id}`, payload);
   return data;
 }
 
 export async function deleteSubject(id: number) {
-  await api.delete(`/subjects/${id}`);
+  await api.delete(`${SUBJECTS_ENDPOINT}/${id}`);
 }
 
 export async function getAllSubjects() {
-  const { data } = await api.get<Paginated<Subject>>('/subjects', {
+  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/teachers.ts
+++ b/src/app/services/teachers.ts
@@ -3,6 +3,8 @@ import type { Paginated, Teacher, TeacherFilters, TeacherPayload } from '@/app/t
 
 export const TEACHERS_PAGE_SIZE = 10;
 
+const TEACHERS_ENDPOINT = '/docentes';
+
 export async function getTeachers(filters: TeacherFilters) {
   const { page, search, page_size = TEACHERS_PAGE_SIZE } = filters;
   const params: Record<string, unknown> = {
@@ -14,27 +16,27 @@ export async function getTeachers(filters: TeacherFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Teacher>>('/teachers', {
+  const { data } = await api.get<Paginated<Teacher>>(TEACHERS_ENDPOINT, {
     params,
   });
   return data;
 }
 
 export async function createTeacher(payload: TeacherPayload) {
-  const { data } = await api.post<Teacher>('/teachers', payload);
+  const { data } = await api.post<Teacher>(TEACHERS_ENDPOINT, payload);
   return data;
 }
 
 export async function getTeacher(id: number) {
-  const { data } = await api.get<Teacher>(`/teachers/${id}`);
+  const { data } = await api.get<Teacher>(`${TEACHERS_ENDPOINT}/${id}`);
   return data;
 }
 
 export async function updateTeacher(id: number, payload: TeacherPayload) {
-  const { data } = await api.put<Teacher>(`/teachers/${id}`, payload);
+  const { data } = await api.patch<Teacher>(`${TEACHERS_ENDPOINT}/${id}`, payload);
   return data;
 }
 
 export async function deleteTeacher(id: number) {
-  await api.delete(`/teachers/${id}`);
+  await api.delete(`${TEACHERS_ENDPOINT}/${id}`);
 }

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -9,6 +9,8 @@ import type {
 
 export const USERS_PAGE_SIZE = 10;
 
+const USERS_ENDPOINT = '/usuarios';
+
 const normalizeRole = (role: ApiManagedUser['role'] | ManagedUser['role'] | string): ManagedUser['role'] => {
   const normalized = `${role}`.toLowerCase();
   if (normalized === 'admin' || normalized === 'administrador') {
@@ -44,7 +46,7 @@ export async function getUsers(filters: UserFilters) {
     params.role = role;
   }
 
-  const { data } = await api.get<Paginated<ApiManagedUser>>('/users', {
+  const { data } = await api.get<Paginated<ApiManagedUser>>(USERS_ENDPOINT, {
     params,
   });
   return {
@@ -54,12 +56,12 @@ export async function getUsers(filters: UserFilters) {
 }
 
 export async function getUser(id: number) {
-  const { data } = await api.get<ApiManagedUser>(`/users/${id}`);
+  const { data } = await api.get<ApiManagedUser>(`${USERS_ENDPOINT}/${id}`);
   return mapUser(data);
 }
 
 export async function createUser(payload: UserPayload) {
-  const { data } = await api.post<ApiManagedUser>('/users', payload);
+  const { data } = await api.post<ApiManagedUser>(USERS_ENDPOINT, payload);
   return mapUser(data);
 }
 
@@ -78,10 +80,10 @@ export async function updateUser(id: number, payload: UserPayload) {
     body.password = payload.password;
   }
 
-  const { data } = await api.put<ApiManagedUser>(`/users/${id}`, body);
+  const { data } = await api.patch<ApiManagedUser>(`${USERS_ENDPOINT}/${id}`, body);
   return mapUser(data);
 }
 
 export async function deleteUser(id: number) {
-  await api.delete(`/users/${id}`);
+  await api.delete(`${USERS_ENDPOINT}/${id}`);
 }


### PR DESCRIPTION
## Summary
- update student, teacher, course, subject, and user services to call the backend's Spanish endpoints
- adjust teacher and user updates to use PATCH, matching the backend's contract
## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6089929a083259c17b21eb55b6f45