### PR TITLE
Fix API endpoints by adding trailing slashes

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { ApiUser, AuthResponse, Role, User } from '@/app/types';
 
 import { AuthContext } from './AuthContext';
@@ -60,7 +60,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     formData.append('password', password);
 
     const { data } = await api.post<AuthResponse>(
-      '/auth/login',
+      withTrailingSlash('/auth/login'),
       formData,
       {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -4,6 +4,8 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '/api',
 });
 
+export const withTrailingSlash = (path: string) => (path.endsWith('/') ? path : `${path}/`);
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('access_token');
   if (token) {

--- a/src/app/services/courses.ts
+++ b/src/app/services/courses.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { Course, CourseFilters, CoursePayload, Paginated } from '@/app/types';
 
 export const COURSES_PAGE_SIZE = 10;
@@ -16,7 +16,7 @@ export async function getCourses(filters: CourseFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Course>>(COURSES_ENDPOINT, {
+  const { data } = await api.get<Paginated<Course>>(withTrailingSlash(COURSES_ENDPOINT), {
     params,
   });
   return data;
@@ -28,7 +28,7 @@ export async function getCourse(id: number) {
 }
 
 export async function createCourse(payload: CoursePayload) {
-  const { data } = await api.post<Course>(COURSES_ENDPOINT, payload);
+  const { data } = await api.post<Course>(withTrailingSlash(COURSES_ENDPOINT), payload);
   return data;
 }
 
@@ -42,7 +42,7 @@ export async function deleteCourse(id: number) {
 }
 
 export async function getAllCourses() {
-  const { data } = await api.get<Paginated<Course>>(COURSES_ENDPOINT, {
+  const { data } = await api.get<Paginated<Course>>(withTrailingSlash(COURSES_ENDPOINT), {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/people.ts
+++ b/src/app/services/people.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { ApiPerson, Paginated, Person, PersonFilters, PersonPayload } from '@/app/types';
 
 export const PEOPLE_PAGE_SIZE = 10;
@@ -56,7 +56,7 @@ export async function getPeople(filters: PersonFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<ApiPerson>>(PEOPLE_ENDPOINT, {
+  const { data } = await api.get<Paginated<ApiPerson>>(withTrailingSlash(PEOPLE_ENDPOINT), {
     params,
   });
   return {
@@ -72,7 +72,7 @@ export async function getPerson(id: number) {
 
 export async function createPerson(payload: PersonPayload) {
   const body = mapPayloadToApi(payload);
-  const { data } = await api.post<ApiPerson>(PEOPLE_ENDPOINT, body);
+  const { data } = await api.post<ApiPerson>(withTrailingSlash(PEOPLE_ENDPOINT), body);
   return mapPerson(data);
 }
 
@@ -87,7 +87,7 @@ export async function deletePerson(id: number) {
 }
 
 export async function getAllPeople() {
-  const { data } = await api.get<Paginated<ApiPerson>>(PEOPLE_ENDPOINT, {
+  const { data } = await api.get<Paginated<ApiPerson>>(withTrailingSlash(PEOPLE_ENDPOINT), {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/students.ts
+++ b/src/app/services/students.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { Paginated, Student, StudentFilters, StudentPayload } from '@/app/types';
 
 export const STUDENTS_PAGE_SIZE = 10;
@@ -16,14 +16,14 @@ export async function getStudents(filters: StudentFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Student>>(STUDENTS_ENDPOINT, {
+  const { data } = await api.get<Paginated<Student>>(withTrailingSlash(STUDENTS_ENDPOINT), {
     params,
   });
   return data;
 }
 
 export async function createStudent(payload: StudentPayload) {
-  const { data } = await api.post<Student>(STUDENTS_ENDPOINT, payload);
+  const { data } = await api.post<Student>(withTrailingSlash(STUDENTS_ENDPOINT), payload);
   return data;
 }
 

--- a/src/app/services/subjects.ts
+++ b/src/app/services/subjects.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { Paginated, Subject, SubjectFilters, SubjectPayload } from '@/app/types';
 
 export const SUBJECTS_PAGE_SIZE = 10;
@@ -20,7 +20,7 @@ export async function getSubjects(filters: SubjectFilters) {
     params.curso_id = curso_id;
   }
 
-  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
+  const { data } = await api.get<Paginated<Subject>>(withTrailingSlash(SUBJECTS_ENDPOINT), {
     params,
   });
   return data;
@@ -32,7 +32,7 @@ export async function getSubject(id: number) {
 }
 
 export async function createSubject(payload: SubjectPayload) {
-  const { data } = await api.post<Subject>(SUBJECTS_ENDPOINT, payload);
+  const { data } = await api.post<Subject>(withTrailingSlash(SUBJECTS_ENDPOINT), payload);
   return data;
 }
 
@@ -46,7 +46,7 @@ export async function deleteSubject(id: number) {
 }
 
 export async function getAllSubjects() {
-  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
+  const { data } = await api.get<Paginated<Subject>>(withTrailingSlash(SUBJECTS_ENDPOINT), {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/teachers.ts
+++ b/src/app/services/teachers.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type { Paginated, Teacher, TeacherFilters, TeacherPayload } from '@/app/types';
 
 export const TEACHERS_PAGE_SIZE = 10;
@@ -16,14 +16,14 @@ export async function getTeachers(filters: TeacherFilters) {
     params.search = search.trim();
   }
 
-  const { data } = await api.get<Paginated<Teacher>>(TEACHERS_ENDPOINT, {
+  const { data } = await api.get<Paginated<Teacher>>(withTrailingSlash(TEACHERS_ENDPOINT), {
     params,
   });
   return data;
 }
 
 export async function createTeacher(payload: TeacherPayload) {
-  const { data } = await api.post<Teacher>(TEACHERS_ENDPOINT, payload);
+  const { data } = await api.post<Teacher>(withTrailingSlash(TEACHERS_ENDPOINT), payload);
   return data;
 }
 

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -1,4 +1,4 @@
-import api from '@/app/services/api';
+import api, { withTrailingSlash } from '@/app/services/api';
 import type {
   ApiManagedUser,
   ManagedUser,
@@ -46,7 +46,7 @@ export async function getUsers(filters: UserFilters) {
     params.role = role;
   }
 
-  const { data } = await api.get<Paginated<ApiManagedUser>>(USERS_ENDPOINT, {
+  const { data } = await api.get<Paginated<ApiManagedUser>>(withTrailingSlash(USERS_ENDPOINT), {
     params,
   });
   return {
@@ -61,7 +61,7 @@ export async function getUser(id: number) {
 }
 
 export async function createUser(payload: UserPayload) {
-  const { data } = await api.post<ApiManagedUser>(USERS_ENDPOINT, payload);
+  const { data } = await api.post<ApiManagedUser>(withTrailingSlash(USERS_ENDPOINT), payload);
   return mapUser(data);
 }
 


### PR DESCRIPTION
## Summary
- add a helper to ensure API requests hit trailing-slash endpoints expected by the backend
- update authentication and entity services to use the new helper to avoid losing the Authorization header during redirects

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60bead5a883258130b97fc383b2a9