### PR TITLE
Update person form to new personas schema

### DIFF
--- a/src/app/services/people.ts
+++ b/src/app/services/people.ts
@@ -5,37 +5,29 @@ export const PEOPLE_PAGE_SIZE = 10;
 
 const PEOPLE_ENDPOINT = '/personas';
 
-const mapPerson = (person: ApiPerson): Person => {
-  const celular = person.celular ?? null;
-  const ciNumero = person.ci_numero ?? null;
-
-  return {
-    id: person.id,
-    nombres: person.nombres,
-    apellidos: person.apellidos,
-    direccion: person.direccion ?? null,
-    telefono: celular,
-    correo: person.correo ?? null,
-    ci: ciNumero,
-    sexo: person.sexo ?? null,
-    fecha_nacimiento: person.fecha_nacimiento ?? null,
-    celular,
-    ci_numero: ciNumero,
-    ci_complemento: person.ci_complemento ?? null,
-    ci_expedicion: person.ci_expedicion ?? null,
-  };
-};
+const mapPerson = (person: ApiPerson): Person => ({
+  id: person.id,
+  nombres: person.nombres,
+  apellidos: person.apellidos,
+  sexo: person.sexo ?? null,
+  fecha_nacimiento: person.fecha_nacimiento ?? null,
+  celular: person.celular ?? null,
+  direccion: person.direccion ?? null,
+  ci_numero: person.ci_numero ?? null,
+  ci_complemento: person.ci_complemento ?? null,
+  ci_expedicion: person.ci_expedicion ?? null,
+  correo: person.correo ?? null,
+});
 
 const mapPayloadToApi = (payload: PersonPayload) => {
   const body: Record<string, unknown> = {
     nombres: payload.nombres,
     apellidos: payload.apellidos,
-    direccion: payload.direccion,
-    celular: payload.celular ?? payload.telefono,
-    correo: payload.correo,
     sexo: payload.sexo,
     fecha_nacimiento: payload.fecha_nacimiento,
-    ci_numero: payload.ci_numero ?? payload.ci,
+    celular: payload.celular,
+    direccion: payload.direccion,
+    ci_numero: payload.ci_numero,
     ci_complemento: payload.ci_complemento,
     ci_expedicion: payload.ci_expedicion,
   };

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -74,31 +74,26 @@ export interface Person {
   id: number;
   nombres: string;
   apellidos: string;
-  direccion?: string | null;
-  telefono?: string | null;
+  sexo: string | null;
+  fecha_nacimiento: string | null;
+  celular: string | null;
+  direccion: string | null;
+  ci_numero: string | null;
+  ci_complemento: string | null;
+  ci_expedicion: string | null;
   correo?: string | null;
-  ci?: string | null;
-  sexo?: string | null;
-  fecha_nacimiento?: string | null;
-  celular?: string | null;
-  ci_numero?: string | null;
-  ci_complemento?: string | null;
-  ci_expedicion?: string | null;
 }
 
 export interface PersonPayload {
-  ci: string;
   nombres: string;
   apellidos: string;
+  sexo: string;
+  fecha_nacimiento: string;
+  celular?: string;
   direccion?: string;
-  telefono?: string;
-  correo?: string;
-  sexo?: string;
-  fecha_nacimiento?: string;
+  ci_numero?: string;
   ci_complemento?: string;
   ci_expedicion?: string;
-  ci_numero?: string;
-  celular?: string;
 }
 
 export type PersonFilters = PaginationFilters;

--- a/src/pages/people/PeopleList.tsx
+++ b/src/pages/people/PeopleList.tsx
@@ -56,6 +56,13 @@ export default function PeopleList() {
 
   const formatFullName = (person: Person) => `${person.apellidos} ${person.nombres}`.trim();
 
+  const formatBirthDate = (value: string | null) => {
+    if (!value) {
+      return '-';
+    }
+    return value.slice(0, 10);
+  };
+
   return (
     <div className="bg-white rounded-2xl shadow p-4">
       <div className="flex items-center justify-between mb-4">
@@ -90,18 +97,20 @@ export default function PeopleList() {
               <tr className="text-left border-b">
                 <th className="py-2">CI</th>
                 <th>Nombre</th>
-                <th>Teléfono</th>
-                <th>Correo</th>
+                <th>Sexo</th>
+                <th>Fecha de nacimiento</th>
+                <th>Celular</th>
                 <th>Acciones</th>
               </tr>
             </thead>
             <tbody>
               {people.map((person) => (
                 <tr key={person.id} className="border-b last:border-0">
-                  <td className="py-2">{person.ci || '-'}</td>
+                  <td className="py-2">{person.ci_numero || '-'}</td>
                   <td>{formatFullName(person)}</td>
-                  <td>{person.telefono || '-'}</td>
-                  <td>{person.correo || '-'}</td>
+                  <td>{person.sexo || '-'}</td>
+                  <td>{formatBirthDate(person.fecha_nacimiento)}</td>
+                  <td>{person.celular || '-'}</td>
                   <td>
                     <div className="flex gap-2">
                       <Link

--- a/src/pages/users/UserForm.tsx
+++ b/src/pages/users/UserForm.tsx
@@ -223,7 +223,8 @@ export default function UserForm() {
             <option value="">Selecciona una persona…</option>
             {peopleOptions.map((person) => (
               <option key={person.id} value={person.id}>
-                {`${person.apellidos} ${person.nombres}`.trim()} {person.ci ? `• ${person.ci}` : ''}
+                {`${person.apellidos} ${person.nombres}`.trim()}{' '}
+                {person.ci_numero ? `• ${person.ci_numero}` : ''}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- align person types and service mapping with the personas/ci tables
- refresh the people form to capture sexo, nacimiento, celular and CI details with updated validation
- update listings and selectors to use the CI número and show the new fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d618e4bc1083259f27c649e85a2112