### PR TITLE
Require celular in person payload

### DIFF
--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -97,7 +97,7 @@ export interface PersonPayload {
   apellidos: string;
   sexo: Sexo;
   fecha_nacimiento: string;
-  celular?: string;
+  celular: string;
   direccion?: string;
   ci_numero?: string;
   ci_complemento?: string;

--- a/src/pages/people/PersonForm.tsx
+++ b/src/pages/people/PersonForm.tsx
@@ -19,7 +19,10 @@ const personSchema = z.object({
   fecha_nacimiento: z
     .string()
     .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, 'Ingresa una fecha válida (YYYY-MM-DD)'),
-  celular: z.string().max(20, 'Máximo 20 caracteres').optional(),
+  celular: z
+    .string()
+    .min(1, 'Ingresa el celular')
+    .max(20, 'Máximo 20 caracteres'),
   direccion: z.string().max(255, 'Máximo 255 caracteres').optional(),
   ci_numero: z.string().max(20, 'Máximo 20 caracteres').optional(),
   ci_complemento: z.string().max(5, 'Máximo 5 caracteres').optional(),
@@ -113,7 +116,7 @@ export default function PersonForm() {
       apellidos: form.apellidos.trim(),
       sexo: form.sexo,
       fecha_nacimiento: form.fecha_nacimiento,
-      celular: form.celular.trim() || undefined,
+      celular: form.celular.trim(),
       direccion: form.direccion.trim() || undefined,
       ci_numero: form.ci_numero.trim() || undefined,
       ci_complemento: form.ci_complemento.trim() || undefined,


### PR DESCRIPTION
## Summary
- make the person payload celular field mandatory to match backend expectations
- require celular input in the person form and send the trimmed string in submissions

## Testing
- npm run lint *(fails: existing react-hooks/rules-of-hooks warning in src/pages/users/UserForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d622df7288832582246007b8ec1440