### PR TITLE
Add role management UI and audit log screen

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -19,6 +19,8 @@ const navItems = [
   { to: '/cursos', label: 'Cursos', roles: ['admin'] },
   { to: '/materias', label: 'Materias', roles: ['admin'] },
   { to: '/usuarios', label: 'Usuarios', roles: ['admin'] },
+  { to: '/roles', label: 'Roles', roles: ['admin'] },
+  { to: '/auditoria', label: 'Auditoría', roles: ['admin'] },
 ];
 
 export default function Sidebar({ className = '', onNavigate }: SidebarProps) {

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -18,6 +18,9 @@ import PeopleList from '@/pages/people/PeopleList';
 import PersonForm from '@/pages/people/PersonForm';
 import UsersList from '@/pages/users/UsersList';
 import UserForm from '@/pages/users/UserForm';
+import RolesList from '@/pages/roles/RolesList';
+import RoleForm from '@/pages/roles/RoleForm';
+import AuditLog from '@/pages/audit/AuditLog';
 
 export default function AppRouter() {
   const { isAuthenticated } = useAuth();
@@ -52,6 +55,10 @@ export default function AppRouter() {
             <Route path="usuarios" element={<UsersList />} />
             <Route path="usuarios/nuevo" element={<UserForm />} />
             <Route path="usuarios/:userId/editar" element={<UserForm />} />
+            <Route path="roles" element={<RolesList />} />
+            <Route path="roles/nuevo" element={<RoleForm />} />
+            <Route path="roles/:roleId/editar" element={<RoleForm />} />
+            <Route path="auditoria" element={<AuditLog />} />
           </Route>
         </Route>
       </Route>

--- a/src/app/services/audit.ts
+++ b/src/app/services/audit.ts
@@ -1,0 +1,42 @@
+import api, { withTrailingSlash } from '@/app/services/api';
+import type {
+  ApiAuditLogEntry,
+  AuditLogEntry,
+  AuditLogFilters,
+  Paginated,
+} from '@/app/types';
+
+export const AUDIT_LOG_PAGE_SIZE = 10;
+
+const AUDIT_LOG_ENDPOINT = '/auditoria';
+
+const mapAuditEntry = (entry: ApiAuditLogEntry): AuditLogEntry => ({
+  id: entry.id,
+  action: entry.accion,
+  resource: entry.recurso,
+  actor: entry.usuario,
+  timestamp: entry.fecha,
+  device: entry.dispositivo ?? null,
+  ip: entry.ip ?? null,
+});
+
+export async function getAuditLog(filters: AuditLogFilters) {
+  const { page, search, page_size = AUDIT_LOG_PAGE_SIZE } = filters;
+  const params: Record<string, unknown> = {
+    page,
+    page_size,
+  };
+
+  if (typeof search === 'string' && search.trim().length > 0) {
+    params.search = search.trim();
+  }
+
+  const { data } = await api.get<Paginated<ApiAuditLogEntry>>(withTrailingSlash(AUDIT_LOG_ENDPOINT), {
+    params,
+  });
+
+  return {
+    ...data,
+    items: data.items.map(mapAuditEntry),
+  };
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -191,3 +191,75 @@ export interface UserPayload {
 export interface UserFilters extends PaginationFilters {
   role?: Role;
 }
+
+export interface ApiRoleOption {
+  id: number;
+  nombre: string;
+  clave: string;
+}
+
+export interface RoleOption {
+  id: number;
+  nombre: string;
+  clave: Role;
+}
+
+export interface ApiRoleView {
+  id: number;
+  nombre: string;
+  codigo: string;
+  descripcion?: string | null;
+}
+
+export interface RoleView {
+  id: number;
+  nombre: string;
+  codigo: string;
+  descripcion?: string | null;
+}
+
+export interface ApiRoleDefinition {
+  id: number;
+  nombre: string;
+  descripcion?: string | null;
+  vistas?: ApiRoleView[];
+  vista_ids?: number[];
+}
+
+export interface RoleDefinition {
+  id: number;
+  nombre: string;
+  descripcion?: string | null;
+  vistas: RoleView[];
+  vista_ids: number[];
+}
+
+export type RoleFilters = PaginationFilters;
+
+export interface RolePayload {
+  nombre: string;
+  descripcion?: string;
+  vista_ids: number[];
+}
+
+export interface ApiAuditLogEntry {
+  id: number;
+  accion: string;
+  recurso: string;
+  usuario: string;
+  fecha: string;
+  dispositivo?: string | null;
+  ip?: string | null;
+}
+
+export interface AuditLogEntry {
+  id: number;
+  action: string;
+  resource: string;
+  actor: string;
+  timestamp: string;
+  device?: string | null;
+  ip?: string | null;
+}
+
+export type AuditLogFilters = PaginationFilters;

--- a/src/pages/audit/AuditLog.tsx
+++ b/src/pages/audit/AuditLog.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { AUDIT_LOG_PAGE_SIZE, getAuditLog } from '@/app/services/audit';
+import type { AuditLogEntry } from '@/app/types';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+const dateTimeFormatter = new Intl.DateTimeFormat('es-BO', {
+  dateStyle: 'short',
+  timeStyle: 'medium',
+});
+
+export default function AuditLog() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ['audit-log', page, debouncedSearch],
+    queryFn: async () =>
+      getAuditLog({
+        page,
+        search: debouncedSearch || undefined,
+        page_size: AUDIT_LOG_PAGE_SIZE,
+      }),
+    placeholderData: (previousData) => previousData,
+  });
+
+  const entries: AuditLogEntry[] = data?.items ?? [];
+  const pageSize = data?.page_size ?? AUDIT_LOG_PAGE_SIZE;
+  const isEmpty = !isLoading && !isError && entries.length === 0;
+  const disablePrevious = page === 1 || isFetching;
+  const disableNext = entries.length < pageSize || isFetching;
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-semibold">Bitácora de auditoría</h1>
+      </div>
+
+      <div className="mb-3">
+        <label className="block text-sm font-medium text-gray-600 mb-1" htmlFor="audit-search">
+          Buscar
+        </label>
+        <input
+          id="audit-search"
+          placeholder="Buscar por acción, recurso o usuario…"
+          className="border rounded px-3 py-2 w-full"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      </div>
+
+      {isLoading && <p>Cargando…</p>}
+      {isError && <p className="text-red-600">Error al cargar la bitácora.</p>}
+      {isFetching && !isLoading && <p className="text-sm text-gray-500">Actualizando…</p>}
+      {isEmpty && <p className="text-sm text-gray-500">No se encontraron registros.</p>}
+
+      {entries.length > 0 && (
+        <>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">Acción</th>
+                <th>Recurso</th>
+                <th>Usuario</th>
+                <th>Fecha y hora</th>
+                <th>Dispositivo / IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => {
+                const formattedDate = (() => {
+                  try {
+                    return dateTimeFormatter.format(new Date(entry.timestamp));
+                  } catch (error) {
+                    return entry.timestamp;
+                  }
+                })();
+                const deviceInfo = [entry.device, entry.ip].filter(Boolean).join(' • ');
+                return (
+                  <tr key={entry.id} className="border-b last:border-0">
+                    <td className="py-2">{entry.action}</td>
+                    <td className="max-w-xs truncate" title={entry.resource}>
+                      {entry.resource}
+                    </td>
+                    <td>{entry.actor}</td>
+                    <td>{formattedDate}</td>
+                    <td className="max-w-xs truncate" title={deviceInfo || undefined}>
+                      {deviceInfo || '-'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div className="flex items-center gap-2 justify-end mt-4">
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              disabled={disablePrevious}
+            >
+              Anterior
+            </button>
+            <span>Página {page}</span>
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => current + 1)}
+              disabled={disableNext}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/people/PersonForm.tsx
+++ b/src/pages/people/PersonForm.tsx
@@ -11,11 +11,7 @@ import type { PersonPayload, Sexo } from '@/app/types';
 const personSchema = z.object({
   nombres: z.string().min(1, 'Ingresa los nombres').max(120, 'Máximo 120 caracteres'),
   apellidos: z.string().min(1, 'Ingresa los apellidos').max(120, 'Máximo 120 caracteres'),
-  sexo: z.enum(SEX_CODES, {
-    errorMap: () => ({
-      message: 'Selecciona un sexo válido',
-    }),
-  }),
+  sexo: z.enum(SEX_CODES, { message: 'Selecciona un sexo válido' }),
   fecha_nacimiento: z
     .string()
     .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, 'Ingresa una fecha válida (YYYY-MM-DD)'),

--- a/src/pages/roles/RoleForm.tsx
+++ b/src/pages/roles/RoleForm.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { FormEvent } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { z } from 'zod';
+
+import { createRole, getAvailableRoleViews, getRole, updateRole } from '@/app/services/roles';
+import type { RolePayload, RoleView } from '@/app/types';
+
+const roleSchema = z.object({
+  nombre: z.string().min(3, 'Ingresa un nombre para el rol'),
+  descripcion: z.string().optional(),
+  vista_ids: z.array(z.number().int()).optional(),
+});
+
+type RoleFormState = {
+  nombre: string;
+  descripcion: string;
+  vistaIds: string[];
+};
+
+type FieldErrors = Partial<{
+  nombre: string;
+  descripcion: string;
+  vista_ids: string;
+}>;
+
+const initialValues: RoleFormState = {
+  nombre: '',
+  descripcion: '',
+  vistaIds: [],
+};
+
+export default function RoleForm() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { roleId } = useParams();
+  const isEditing = Boolean(roleId);
+  const [form, setForm] = useState<RoleFormState>(initialValues);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState('');
+
+  const roleQuery = useQuery({
+    queryKey: ['role', roleId],
+    queryFn: async () => (roleId ? getRole(Number(roleId)) : null),
+    enabled: isEditing,
+  });
+
+  const viewsQuery = useQuery({
+    queryKey: ['role-views'],
+    queryFn: async () => getAvailableRoleViews(),
+  });
+
+  useEffect(() => {
+    if (roleQuery.data) {
+      setForm({
+        nombre: roleQuery.data.nombre,
+        descripcion: roleQuery.data.descripcion ?? '',
+        vistaIds: roleQuery.data.vista_ids.map((id) => id.toString()),
+      });
+    }
+  }, [roleQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: RolePayload) =>
+      roleId ? updateRole(Number(roleId), payload) : createRole(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['roles'] });
+      if (roleId) {
+        queryClient.invalidateQueries({ queryKey: ['role', roleId] });
+      }
+      navigate('/roles');
+    },
+    onError: (error: unknown) => {
+      const message =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? // @ts-expect-error Axios style error shape
+            error.response?.data?.detail ?? 'No se pudo guardar'
+          : 'No se pudo guardar';
+      setSubmitError(typeof message === 'string' ? message : 'No se pudo guardar');
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError('');
+
+    const result = roleSchema.safeParse({
+      nombre: form.nombre.trim(),
+      descripcion: form.descripcion.trim() || undefined,
+      vista_ids: form.vistaIds.map((value) => Number(value)).filter((value) => !Number.isNaN(value)),
+    });
+
+    if (!result.success) {
+      const newErrors: FieldErrors = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0];
+        if (typeof field === 'string' && !(field in newErrors)) {
+          newErrors[field as keyof FieldErrors] = issue.message;
+        }
+      }
+      setFieldErrors(newErrors);
+      return;
+    }
+
+    const payload: RolePayload = {
+      nombre: result.data.nombre,
+      descripcion: result.data.descripcion,
+      vista_ids: result.data.vista_ids ?? [],
+    };
+
+    mutation.mutate(payload);
+  };
+
+  const updateField = (field: keyof RoleFormState) => (value: string | string[]) => {
+    setFieldErrors((previous) => {
+      if (!previous[field === 'vistaIds' ? 'vista_ids' : field]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[field === 'vistaIds' ? 'vista_ids' : field];
+      return next;
+    });
+
+    setForm((previous) => ({
+      ...previous,
+      [field]: value,
+    }));
+  };
+
+  if (isEditing && roleQuery.isLoading) {
+    return <p>Cargando rol…</p>;
+  }
+
+  if (isEditing && roleQuery.isError) {
+    return <p className="text-red-600">No se pudo cargar la información del rol.</p>;
+  }
+
+  const title = isEditing ? 'Editar rol' : 'Nuevo rol';
+
+  const availableViews = useMemo<RoleView[]>(() => viewsQuery.data ?? [], [viewsQuery.data]);
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4 max-w-3xl">
+      <h1 className="text-lg font-semibold mb-4">{title}</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="role-name">
+              Nombre
+            </label>
+            <input
+              id="role-name"
+              className="w-full border rounded px-3 py-2"
+              value={form.nombre}
+              onChange={(event) => updateField('nombre')(event.target.value)}
+            />
+            {fieldErrors.nombre && <p className="text-sm text-red-600 mt-1">{fieldErrors.nombre}</p>}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="role-description">
+              Descripción
+            </label>
+            <input
+              id="role-description"
+              className="w-full border rounded px-3 py-2"
+              value={form.descripcion}
+              onChange={(event) => updateField('descripcion')(event.target.value)}
+              placeholder="Opcional"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-600" htmlFor="role-views">
+            Vistas permitidas
+          </label>
+          <select
+            id="role-views"
+            multiple
+            className="w-full border rounded px-3 py-2 min-h-32"
+            value={form.vistaIds}
+            onChange={(event) =>
+              updateField('vistaIds')(
+                Array.from(event.target.selectedOptions, (option) => option.value),
+              )
+            }
+            disabled={viewsQuery.isLoading}
+          >
+            {availableViews.map((view) => (
+              <option key={view.id} value={view.id.toString()}>
+                {view.nombre} ({view.codigo})
+              </option>
+            ))}
+          </select>
+          {viewsQuery.isError && (
+            <p className="text-sm text-red-600 mt-1">No se pudieron cargar las vistas disponibles.</p>
+          )}
+          {fieldErrors.vista_ids && (
+            <p className="text-sm text-red-600 mt-1">{fieldErrors.vista_ids}</p>
+          )}
+          <p className="text-xs text-gray-500 mt-1">
+            Mantén presionada la tecla Ctrl (Cmd en Mac) para seleccionar varias opciones.
+          </p>
+        </div>
+
+        {submitError && <p className="text-red-600 text-sm">{submitError}</p>}
+
+        <div className="flex gap-2 justify-end">
+          <button type="button" className="px-3 py-2 border rounded" onClick={() => navigate(-1)}>
+            Cancelar
+          </button>
+          <button
+            className="px-3 py-2 rounded bg-gray-900 text-white disabled:opacity-50"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/roles/RolesList.tsx
+++ b/src/pages/roles/RolesList.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+
+import { deleteRole, getRoles, ROLES_PAGE_SIZE } from '@/app/services/roles';
+import type { RoleDefinition } from '@/app/types';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export default function RolesList() {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedSearch(search.trim());
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, [search]);
+
+  const { data, isLoading, isError, isFetching } = useQuery({
+    queryKey: ['roles', page, debouncedSearch],
+    queryFn: async () =>
+      getRoles({
+        page,
+        search: debouncedSearch || undefined,
+        page_size: ROLES_PAGE_SIZE,
+      }),
+    placeholderData: (previousData) => previousData,
+  });
+
+  const roles: RoleDefinition[] = useMemo(() => data?.items ?? [], [data?.items]);
+  const pageSize = data?.page_size ?? ROLES_PAGE_SIZE;
+  const isEmpty = !isLoading && !isError && roles.length === 0;
+  const disablePrevious = page === 1 || isFetching;
+  const disableNext = roles.length < pageSize || isFetching;
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => deleteRole(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['roles'] });
+    },
+  });
+
+  const handleDelete = (id: number) => {
+    const confirmed = window.confirm('¿Deseas eliminar este rol?');
+    if (!confirmed) {
+      return;
+    }
+    deleteMutation.mutate(id);
+  };
+
+  return (
+    <div className="bg-white rounded-2xl shadow p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-lg font-semibold">Roles</h1>
+        <Link to="/roles/nuevo" className="px-3 py-2 rounded bg-gray-900 text-white">
+          Nuevo
+        </Link>
+      </div>
+
+      <div className="mb-3">
+        <label className="block text-sm font-medium text-gray-600 mb-1" htmlFor="roles-search">
+          Buscar
+        </label>
+        <input
+          id="roles-search"
+          placeholder="Buscar por nombre de rol…"
+          className="border rounded px-3 py-2 w-full"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      </div>
+
+      {isLoading && <p>Cargando…</p>}
+      {isError && <p className="text-red-600">Error al cargar los roles.</p>}
+      {isFetching && !isLoading && <p className="text-sm text-gray-500">Actualizando…</p>}
+      {isEmpty && <p className="text-sm text-gray-500">No se encontraron roles.</p>}
+
+      {roles.length > 0 && (
+        <>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-2">Nombre</th>
+                <th>Descripción</th>
+                <th>Vistas</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {roles.map((role) => {
+                const views = role.vistas ?? [];
+                const viewsLabel =
+                  views.length > 0 ? views.map((view) => view.nombre).join(', ') : '-';
+                return (
+                  <tr key={role.id} className="border-b last:border-0">
+                    <td className="py-2">{role.nombre}</td>
+                    <td className="max-w-sm truncate" title={role.descripcion ?? undefined}>
+                      {role.descripcion || '-'}
+                    </td>
+                    <td className="max-w-sm truncate" title={viewsLabel}>
+                      {views.length > 0 ? `${views.length} vistas` : '-'}
+                    </td>
+                    <td>
+                      <div className="flex gap-2">
+                        <Link
+                          to={`/roles/${role.id}/editar`}
+                          className="text-sm text-blue-600 hover:underline"
+                        >
+                          Editar
+                        </Link>
+                        <button
+                          type="button"
+                          className="text-sm text-red-600 hover:underline"
+                          onClick={() => handleDelete(role.id)}
+                          disabled={deleteMutation.isPending}
+                        >
+                          Eliminar
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          {deleteMutation.isError && (
+            <p className="text-sm text-red-600 mt-2">No se pudo eliminar el rol.</p>
+          )}
+
+          <div className="flex items-center gap-2 justify-end mt-4">
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => Math.max(1, current - 1))}
+              disabled={disablePrevious}
+            >
+              Anterior
+            </button>
+            <span>Página {page}</span>
+            <button
+              className="px-3 py-1 border rounded disabled:opacity-50"
+              onClick={() => setPage((current) => current + 1)}
+              disabled={disableNext}
+            >
+              Siguiente
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add role management services, routes, and screens including multi-select views for roles
- fetch role options for user management and require selecting an available role
- expose the read-only audit log screen and hook services plus navigation updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db16111ed88325a771d5ed65c81f9e