### PR TITLE
Enforce ROLES view permissions on role management UI

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { NavLink } from 'react-router-dom';
 
 import { useAuth } from '@/app/hooks/useAuth';
+import type { Role, ViewCode } from '@/app/types';
 
 const linkBase = 'block px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors';
 const linkClassName = ({ isActive }: { isActive: boolean }) =>
@@ -11,7 +12,14 @@ type SidebarProps = {
   onNavigate?: () => void;
 };
 
-const navItems = [
+type NavItem = {
+  to: string;
+  label: string;
+  roles?: Role[];
+  requiredView?: ViewCode;
+};
+
+const navItems: NavItem[] = [
   { to: '/', label: 'Dashboard', roles: ['admin', 'docente', 'padre'] },
   { to: '/estudiantes', label: 'Estudiantes', roles: ['admin', 'docente'] },
   { to: '/docentes', label: 'Docentes', roles: ['admin'] },
@@ -19,16 +27,23 @@ const navItems = [
   { to: '/cursos', label: 'Cursos', roles: ['admin'] },
   { to: '/materias', label: 'Materias', roles: ['admin'] },
   { to: '/usuarios', label: 'Usuarios', roles: ['admin'] },
-  { to: '/roles', label: 'Roles', roles: ['admin'] },
+  { to: '/roles', label: 'Roles', roles: ['admin'], requiredView: 'ROLES' },
   { to: '/auditoria', label: 'Auditoría', roles: ['admin'] },
 ];
 
 export default function Sidebar({ className = '', onNavigate }: SidebarProps) {
-  const { user } = useAuth();
+  const { user, hasView } = useAuth();
 
-  const allowedItems = navItems.filter((item) =>
-    user ? item.roles.includes(user.role) : false,
-  );
+  const allowedItems = navItems.filter((item) => {
+    if (!user) {
+      return false;
+    }
+
+    const roleAllowed = item.roles ? item.roles.includes(user.role) : true;
+    const viewAllowed = item.requiredView ? hasView(item.requiredView) : true;
+
+    return roleAllowed && viewAllowed;
+  });
 
   if (!user) {
     return null;

--- a/src/app/providers/AuthContext.ts
+++ b/src/app/providers/AuthContext.ts
@@ -1,10 +1,12 @@
 import { createContext } from 'react';
 
-import type { User } from '@/app/types';
+import type { User, ViewCode } from '@/app/types';
 
 type AuthContextValue = {
   user: User | null;
   isAuthenticated: boolean;
+  views: ViewCode[];
+  hasView: (code: ViewCode) => boolean;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 };
@@ -12,6 +14,8 @@ type AuthContextValue = {
 export const AuthContext = createContext<AuthContextValue>({
   user: null,
   isAuthenticated: false,
+  views: [],
+  hasView: () => false,
   login: async () => {},
   logout: () => {},
 });

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -4,6 +4,7 @@ import Layout from '@/app/components/Layout';
 import { useAuth } from '@/app/hooks/useAuth';
 import { ProtectedRoute } from '@/app/router/ProtectedRoute';
 import { RoleGuard } from '@/app/router/RoleGuard';
+import { ViewGuard } from '@/app/router/ViewGuard';
 import Dashboard from '@/pages/Dashboard';
 import Login from '@/pages/Login';
 import CourseForm from '@/pages/courses/CourseForm';
@@ -55,9 +56,11 @@ export default function AppRouter() {
             <Route path="usuarios" element={<UsersList />} />
             <Route path="usuarios/nuevo" element={<UserForm />} />
             <Route path="usuarios/:userId/editar" element={<UserForm />} />
-            <Route path="roles" element={<RolesList />} />
-            <Route path="roles/nuevo" element={<RoleForm />} />
-            <Route path="roles/:roleId/editar" element={<RoleForm />} />
+            <Route element={<ViewGuard required="ROLES" />}> 
+              <Route path="roles" element={<RolesList />} />
+              <Route path="roles/nuevo" element={<RoleForm />} />
+              <Route path="roles/:roleId/editar" element={<RoleForm />} />
+            </Route>
             <Route path="auditoria" element={<AuditLog />} />
           </Route>
         </Route>

--- a/src/app/router/ViewGuard.tsx
+++ b/src/app/router/ViewGuard.tsx
@@ -1,0 +1,18 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { useAuth } from '@/app/hooks/useAuth';
+import type { ViewCode } from '@/app/types';
+
+type ViewGuardProps = {
+  required: ViewCode;
+};
+
+export function ViewGuard({ required }: ViewGuardProps) {
+  const { hasView } = useAuth();
+
+  if (!hasView(required)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/app/services/roles.ts
+++ b/src/app/services/roles.ts
@@ -1,20 +1,18 @@
 import api, { withTrailingSlash } from '@/app/services/api';
+import { getViews, mapView } from '@/app/services/views';
 import type {
   ApiRoleDefinition,
   ApiRoleOption,
-  ApiRoleView,
   Paginated,
   RoleDefinition,
   RoleFilters,
   RoleOption,
   RolePayload,
-  RoleView,
 } from '@/app/types';
 
 export const ROLES_PAGE_SIZE = 10;
 
 const ROLES_ENDPOINT = '/roles';
-const ROLE_VIEWS_ENDPOINT = '/roles/vistas-disponibles';
 const ROLE_OPTIONS_ENDPOINT = '/roles/opciones';
 
 const normalizeRoleKey = (role: string): RoleOption['clave'] => {
@@ -31,18 +29,11 @@ const normalizeRoleKey = (role: string): RoleOption['clave'] => {
   return normalized as RoleOption['clave'];
 };
 
-const mapRoleView = (view: ApiRoleView): RoleView => ({
-  id: view.id,
-  nombre: view.nombre,
-  codigo: view.codigo,
-  descripcion: view.descripcion ?? null,
-});
-
 const mapRole = (role: ApiRoleDefinition): RoleDefinition => ({
   id: role.id,
   nombre: role.nombre,
   descripcion: role.descripcion ?? null,
-  vistas: (role.vistas ?? []).map(mapRoleView),
+  vistas: (role.vistas ?? []).map(mapView),
   vista_ids: role.vista_ids ?? (role.vistas ? role.vistas.map((view) => view.id) : []),
 });
 
@@ -93,8 +84,7 @@ export async function deleteRole(id: number) {
 }
 
 export async function getAvailableRoleViews() {
-  const { data } = await api.get<ApiRoleView[]>(ROLE_VIEWS_ENDPOINT);
-  return data.map(mapRoleView);
+  return getViews();
 }
 
 export async function getRoleOptions() {

--- a/src/app/services/views.ts
+++ b/src/app/services/views.ts
@@ -1,0 +1,16 @@
+import api, { withTrailingSlash } from '@/app/services/api';
+import type { ApiView, View } from '@/app/types';
+
+const VIEWS_ENDPOINT = '/v1/vistas';
+
+export const mapView = (view: ApiView): View => ({
+  id: view.id,
+  nombre: view.nombre,
+  codigo: view.codigo,
+  descripcion: view.descripcion ?? null,
+});
+
+export async function getViews() {
+  const { data } = await api.get<ApiView[]>(withTrailingSlash(VIEWS_ENDPOINT));
+  return data.map(mapView);
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -10,14 +10,52 @@ export type ApiRole =
   | 'Padre'
   | 'PADRE';
 
+export const VIEW_CODES = [
+  'USUARIOS',
+  'ROLES',
+  'DOCENTES',
+  'ASIGNACIONES',
+  'ALERTAS',
+  'NOTAS',
+  'CURSOS',
+  'PLANES',
+  'MATRICULAS',
+  'MATERIAS',
+  'NIVELES',
+  'GESTIONES',
+  'PARALELOS',
+  'REPORTES',
+  'ASISTENCIAS',
+  'AUDITORIA',
+] as const;
+
+export type KnownViewCode = (typeof VIEW_CODES)[number];
+export type ViewCode = KnownViewCode | (string & {});
+
+export interface ApiView {
+  id: number;
+  nombre: string;
+  codigo: string;
+  descripcion?: string | null;
+}
+
+export interface View {
+  id: number;
+  nombre: string;
+  codigo: string;
+  descripcion: string | null;
+}
+
 export interface User {
   id: number;
   name: string;
   role: Role;
+  vistas: View[];
 }
 
-export interface ApiUser extends Omit<User, 'role'> {
+export interface ApiUser extends Omit<User, 'role' | 'vistas'> {
   role: ApiRole;
+  vistas?: (ApiView | View)[];
 }
 
 export interface AuthResponse {
@@ -204,19 +242,9 @@ export interface RoleOption {
   clave: Role;
 }
 
-export interface ApiRoleView {
-  id: number;
-  nombre: string;
-  codigo: string;
-  descripcion?: string | null;
-}
+export type ApiRoleView = ApiView;
 
-export interface RoleView {
-  id: number;
-  nombre: string;
-  codigo: string;
-  descripcion?: string | null;
-}
+export type RoleView = View;
 
 export interface ApiRoleDefinition {
   id: number;


### PR DESCRIPTION
## Summary
- retrieve view definitions from the authenticated /api/v1/vistas/ endpoint and normalize the returned codes
- expose assigned view codes through the auth context so the sidebar and routing can require the ROLES view for role administration
- add a dedicated view guard and shared views service used by the roles API integration

## Testing
- npm run lint *(fails: existing lint errors in AuditLog.tsx, RoleForm.tsx, and UserForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68db27c1547c83259be21eea9ca2281d