### PR TITLE
Load dynamic role options and fix materias auth redirect

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -12,7 +12,7 @@ type AuthProviderProps = {
 };
 
 const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
-  const normalized = `${role}`.toLowerCase();
+  const normalized = `${role}`.trim().toLowerCase();
   if (normalized === 'admin' || normalized === 'administrador') {
     return 'admin';
   }
@@ -23,8 +23,7 @@ const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
     return 'padre';
   }
 
-  console.warn(`Rol desconocido recibido: ${role}. Se usará "admin" por defecto.`);
-  return 'admin';
+  return normalized as Role;
 };
 
 const normalizeViews = (views?: (ApiView | View)[] | null): View[] => {

--- a/src/app/services/roles.ts
+++ b/src/app/services/roles.ts
@@ -16,7 +16,7 @@ const ROLES_ENDPOINT = '/roles';
 const ROLE_OPTIONS_ENDPOINT = '/roles/opciones';
 
 const normalizeRoleKey = (role: string): RoleOption['clave'] => {
-  const normalized = `${role}`.toLowerCase();
+  const normalized = `${role}`.trim().toLowerCase();
   if (normalized === 'administrador' || normalized === 'admin') {
     return 'admin';
   }

--- a/src/app/services/subjects.ts
+++ b/src/app/services/subjects.ts
@@ -20,7 +20,7 @@ export async function getSubjects(filters: SubjectFilters) {
     params.curso_id = curso_id;
   }
 
-  const { data } = await api.get<Paginated<Subject>>(withTrailingSlash(SUBJECTS_ENDPOINT), {
+  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
     params,
   });
   return data;
@@ -46,7 +46,7 @@ export async function deleteSubject(id: number) {
 }
 
 export async function getAllSubjects() {
-  const { data } = await api.get<Paginated<Subject>>(withTrailingSlash(SUBJECTS_ENDPOINT), {
+  const { data } = await api.get<Paginated<Subject>>(SUBJECTS_ENDPOINT, {
     params: {
       page: 1,
       page_size: 1000,

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -12,7 +12,7 @@ export const USERS_PAGE_SIZE = 10;
 const USERS_ENDPOINT = '/usuarios';
 
 const normalizeRole = (role: ApiManagedUser['role'] | ManagedUser['role'] | string): ManagedUser['role'] => {
-  const normalized = `${role}`.toLowerCase();
+  const normalized = `${role}`.trim().toLowerCase();
   if (normalized === 'admin' || normalized === 'administrador') {
     return 'admin';
   }
@@ -22,8 +22,7 @@ const normalizeRole = (role: ApiManagedUser['role'] | ManagedUser['role'] | stri
   if (normalized === 'padre') {
     return 'padre';
   }
-  console.warn(`Rol desconocido recibido: ${role}. Se usará "admin" por defecto.`);
-  return 'admin';
+  return normalized as ManagedUser['role'];
 };
 
 const mapUser = (user: ApiManagedUser): ManagedUser => ({

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -1,4 +1,4 @@
-export type Role = 'admin' | 'docente' | 'padre';
+export type Role = 'admin' | 'docente' | 'padre' | (string & {});
 
 export type ApiRole =
   | Role


### PR DESCRIPTION
## Summary
- allow custom role keys by keeping normalized values instead of forcing the admin/docente/padre defaults
- fetch available role options to drive the users list filter and display labels dynamically
- avoid trailing slash on materias list requests to prevent redirect drops of the authorization header

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2cd031d083258300e9513c802fc8