### PR TITLE
Normalize role aliases across authentication and services

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -11,19 +11,20 @@ type AuthProviderProps = {
   children: ReactNode;
 };
 
+const ROLE_ALIASES: Record<string, Role> = {
+  admin: 'admin',
+  administrador: 'admin',
+  adm: 'admin',
+  docente: 'docente',
+  doc: 'docente',
+  padre: 'padre',
+  pad: 'padre',
+};
+
 const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
   const normalized = `${role}`.trim().toLowerCase();
-  if (normalized === 'admin' || normalized === 'administrador') {
-    return 'admin';
-  }
-  if (normalized === 'docente') {
-    return 'docente';
-  }
-  if (normalized === 'padre') {
-    return 'padre';
-  }
 
-  return normalized as Role;
+  return ROLE_ALIASES[normalized] ?? (normalized as Role);
 };
 
 const normalizeViews = (views?: (ApiView | View)[] | null): View[] => {

--- a/src/app/services/roles.ts
+++ b/src/app/services/roles.ts
@@ -15,18 +15,20 @@ export const ROLES_PAGE_SIZE = 10;
 const ROLES_ENDPOINT = '/roles';
 const ROLE_OPTIONS_ENDPOINT = '/roles/opciones';
 
+const ROLE_ALIASES: Record<string, RoleOption['clave']> = {
+  admin: 'admin',
+  administrador: 'admin',
+  adm: 'admin',
+  docente: 'docente',
+  doc: 'docente',
+  padre: 'padre',
+  pad: 'padre',
+};
+
 const normalizeRoleKey = (role: string): RoleOption['clave'] => {
   const normalized = `${role}`.trim().toLowerCase();
-  if (normalized === 'administrador' || normalized === 'admin') {
-    return 'admin';
-  }
-  if (normalized === 'docente') {
-    return 'docente';
-  }
-  if (normalized === 'padre') {
-    return 'padre';
-  }
-  return normalized as RoleOption['clave'];
+
+  return ROLE_ALIASES[normalized] ?? (normalized as RoleOption['clave']);
 };
 
 const mapRole = (role: ApiRoleDefinition): RoleDefinition => ({

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -11,18 +11,22 @@ export const USERS_PAGE_SIZE = 10;
 
 const USERS_ENDPOINT = '/usuarios';
 
-const normalizeRole = (role: ApiManagedUser['role'] | ManagedUser['role'] | string): ManagedUser['role'] => {
+const ROLE_ALIASES: Record<string, ManagedUser['role']> = {
+  admin: 'admin',
+  administrador: 'admin',
+  adm: 'admin',
+  docente: 'docente',
+  doc: 'docente',
+  padre: 'padre',
+  pad: 'padre',
+};
+
+const normalizeRole = (
+  role: ApiManagedUser['role'] | ManagedUser['role'] | string,
+): ManagedUser['role'] => {
   const normalized = `${role}`.trim().toLowerCase();
-  if (normalized === 'admin' || normalized === 'administrador') {
-    return 'admin';
-  }
-  if (normalized === 'docente') {
-    return 'docente';
-  }
-  if (normalized === 'padre') {
-    return 'padre';
-  }
-  return normalized as ManagedUser['role'];
+
+  return ROLE_ALIASES[normalized] ?? (normalized as ManagedUser['role']);
 };
 
 const mapUser = (user: ApiManagedUser): ManagedUser => ({


### PR DESCRIPTION
## Summary
- align role normalization in the auth provider and user service so backend aliases map to canonical role keys
- update role option normalization to expose canonical role keys in the UI

## Testing
- `npm run lint` *(fails: existing lint errors in AuditLog.tsx and form components)*

------
https://chatgpt.com/codex/tasks/task_e_68db3597889883259df3b601b28f0ea6