### PR TITLE
Fix login request path to avoid redirects

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import api, { withTrailingSlash } from '@/app/services/api';
+import api from '@/app/services/api';
 import type { ApiUser, ApiView, AuthResponse, Role, User, View, ViewCode } from '@/app/types';
 
 import { AuthContext } from './AuthContext';
@@ -87,7 +87,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     formData.append('password', password);
 
     const { data } = await api.post<AuthResponse>(
-      withTrailingSlash('/auth/login'),
+      '/auth/login',
       formData,
       {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
## Summary
- update the AuthProvider login call to hit `/auth/login` without forcing a trailing slash
- prevent redundant redirects when authenticating against the API

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db3801c5bc832581e722703f15f9e9