### PR TITLE
Normaliza los códigos de vistas

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -27,6 +27,10 @@ const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
   return ROLE_ALIASES[normalized] ?? (normalized as Role);
 };
 
+const normalizeViewCode = (code: ApiView['codigo'] | View['codigo'] | string) => {
+  return `${code}`.trim().toUpperCase();
+};
+
 const normalizeViews = (views?: (ApiView | View)[] | null): View[] => {
   if (!Array.isArray(views)) {
     return [];
@@ -35,7 +39,7 @@ const normalizeViews = (views?: (ApiView | View)[] | null): View[] => {
   return views.map((view) => ({
     id: view.id,
     nombre: view.nombre,
-    codigo: view.codigo,
+    codigo: normalizeViewCode(view.codigo),
     descripcion: view.descripcion ?? null,
   }));
 };

--- a/src/app/services/views.ts
+++ b/src/app/services/views.ts
@@ -3,10 +3,14 @@ import type { ApiView, View } from '@/app/types';
 
 const VIEWS_ENDPOINT = '/v1/vistas';
 
+const normalizeViewCode = (code: ApiView['codigo'] | View['codigo'] | string) => {
+  return `${code}`.trim().toUpperCase();
+};
+
 export const mapView = (view: ApiView): View => ({
   id: view.id,
   nombre: view.nombre,
-  codigo: view.codigo,
+  codigo: normalizeViewCode(view.codigo),
   descripcion: view.descripcion ?? null,
 });
 


### PR DESCRIPTION
## Resumen
- normaliza los códigos de las vistas recibidas desde la API para que sean consistentes
- asegura que los códigos guardados en sesión también se conviertan a mayúsculas

## Pruebas
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68db4061924c8325b0dd49eccad0b46d