### PR TITLE
Improve role normalization for navigation access

### DIFF
--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -1,12 +1,7 @@
 import { useMemo } from 'react';
 
 import { useAuth } from '@/app/hooks/useAuth';
-
-const ROLE_LABELS: Record<string, string> = {
-  admin: 'Administrador',
-  docente: 'Docente',
-  padre: 'Padre',
-};
+import { ROLE_LABELS } from '@/app/utils/roles';
 
 type TopbarProps = {
   onToggleSidebar?: () => void;

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -3,28 +3,13 @@ import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import api from '@/app/services/api';
-import type { ApiUser, ApiView, AuthResponse, Role, User, View, ViewCode } from '@/app/types';
+import type { ApiUser, ApiView, AuthResponse, User, View, ViewCode } from '@/app/types';
+import { normalizeRole } from '@/app/utils/roles';
 
 import { AuthContext } from './AuthContext';
 
 type AuthProviderProps = {
   children: ReactNode;
-};
-
-const ROLE_ALIASES: Record<string, Role> = {
-  admin: 'admin',
-  administrador: 'admin',
-  adm: 'admin',
-  docente: 'docente',
-  doc: 'docente',
-  padre: 'padre',
-  pad: 'padre',
-};
-
-const normalizeRole = (role: ApiUser['role'] | Role | string): Role => {
-  const normalized = `${role}`.trim().toLowerCase();
-
-  return ROLE_ALIASES[normalized] ?? (normalized as Role);
 };
 
 const normalizeViewCode = (code: ApiView['codigo'] | View['codigo'] | string) => {

--- a/src/app/services/roles.ts
+++ b/src/app/services/roles.ts
@@ -9,27 +9,12 @@ import type {
   RoleOption,
   RolePayload,
 } from '@/app/types';
+import { normalizeRole } from '@/app/utils/roles';
 
 export const ROLES_PAGE_SIZE = 10;
 
 const ROLES_ENDPOINT = '/roles';
 const ROLE_OPTIONS_ENDPOINT = '/roles/opciones';
-
-const ROLE_ALIASES: Record<string, RoleOption['clave']> = {
-  admin: 'admin',
-  administrador: 'admin',
-  adm: 'admin',
-  docente: 'docente',
-  doc: 'docente',
-  padre: 'padre',
-  pad: 'padre',
-};
-
-const normalizeRoleKey = (role: string): RoleOption['clave'] => {
-  const normalized = `${role}`.trim().toLowerCase();
-
-  return ROLE_ALIASES[normalized] ?? (normalized as RoleOption['clave']);
-};
 
 const mapRole = (role: ApiRoleDefinition): RoleDefinition => ({
   id: role.id,
@@ -42,7 +27,7 @@ const mapRole = (role: ApiRoleDefinition): RoleDefinition => ({
 const mapRoleOption = (role: ApiRoleOption): RoleOption => ({
   id: role.id,
   nombre: role.nombre,
-  clave: normalizeRoleKey(role.clave),
+  clave: normalizeRole(role.clave),
 });
 
 export async function getRoles(filters: RoleFilters) {

--- a/src/app/services/users.ts
+++ b/src/app/services/users.ts
@@ -6,28 +6,11 @@ import type {
   UserFilters,
   UserPayload,
 } from '@/app/types';
+import { normalizeRole } from '@/app/utils/roles';
 
 export const USERS_PAGE_SIZE = 10;
 
 const USERS_ENDPOINT = '/usuarios';
-
-const ROLE_ALIASES: Record<string, ManagedUser['role']> = {
-  admin: 'admin',
-  administrador: 'admin',
-  adm: 'admin',
-  docente: 'docente',
-  doc: 'docente',
-  padre: 'padre',
-  pad: 'padre',
-};
-
-const normalizeRole = (
-  role: ApiManagedUser['role'] | ManagedUser['role'] | string,
-): ManagedUser['role'] => {
-  const normalized = `${role}`.trim().toLowerCase();
-
-  return ROLE_ALIASES[normalized] ?? (normalized as ManagedUser['role']);
-};
 
 const mapUser = (user: ApiManagedUser): ManagedUser => ({
   ...user,

--- a/src/app/utils/roles.ts
+++ b/src/app/utils/roles.ts
@@ -1,0 +1,50 @@
+import type { Role } from '@/app/types';
+
+const ROLE_ALIASES: Record<string, Role> = {
+  admin: 'admin',
+  administrador: 'admin',
+  adm: 'admin',
+  docente: 'docente',
+  doc: 'docente',
+  profesor: 'docente',
+  profe: 'docente',
+  maestro: 'docente',
+  padre: 'padre',
+  pad: 'padre',
+  apoderado: 'padre',
+};
+
+const ROLE_PREFIX_PATTERN = /^(role|rol)[\s._-]*/u;
+
+const sanitizeRole = (value: string): string => {
+  const normalized = value.trim().toLowerCase();
+  const withoutPrefix = normalized.replace(ROLE_PREFIX_PATTERN, '');
+  const candidate = withoutPrefix || normalized;
+
+  return candidate.replace(/\s+/g, ' ').trim();
+};
+
+export const normalizeRole = (role: Role | string): Role => {
+  const raw = typeof role === 'string' ? role : `${role}`;
+  const sanitized = sanitizeRole(raw);
+  const alias = ROLE_ALIASES[sanitized];
+
+  if (alias) {
+    return alias;
+  }
+
+  const compact = sanitized.replace(/[\s._-]+/g, '');
+  const compactAlias = ROLE_ALIASES[compact];
+
+  if (compactAlias) {
+    return compactAlias;
+  }
+
+  return sanitized as Role;
+};
+
+export const ROLE_LABELS: Record<string, string> = {
+  admin: 'Administrador',
+  docente: 'Docente',
+  padre: 'Padre',
+};


### PR DESCRIPTION
## Summary
- add a shared role normalization utility that removes backend prefixes and maps common aliases
- update authentication, role/user services, and the top bar to rely on the shared normalization and labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db457b65e0832594ef91caebdf1b1f