### PR TITLE
Fix topbar role label for undefined roles

### DIFF
--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useAuth } from '@/app/hooks/useAuth';
-import { ROLE_LABELS } from '@/app/utils/roles';
+import { resolveRoleLabel } from '@/app/utils/roles';
 
 type TopbarProps = {
   onToggleSidebar?: () => void;
@@ -18,8 +18,8 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
     const name = typeof user.name === 'string' && user.name.trim() ? user.name.trim() : null;
     const username = typeof user.username === 'string' && user.username.trim() ? user.username.trim() : null;
     const displayNameValue = name ?? username ?? 'Usuario';
-    const normalizedRole = typeof user.role === 'string' ? user.role.trim().toLowerCase() : '';
-    const roleLabelValue = normalizedRole ? ROLE_LABELS[normalizedRole] ?? user.role : '';
+    const roleLabelValue = resolveRoleLabel(user.role) ||
+      (typeof user.role === 'string' && user.role.trim() ? 'Sin rol' : '');
 
     return { displayName: displayNameValue, roleLabel: roleLabelValue };
   }, [user]);

--- a/src/app/utils/roles.ts
+++ b/src/app/utils/roles.ts
@@ -24,9 +24,16 @@ const sanitizeRole = (value: string): string => {
   return candidate.replace(/\s+/g, ' ').trim();
 };
 
+const INVALID_ROLE_VALUES = new Set(['', 'undefined', 'null', 'none', 'ninguno']);
+
 export const normalizeRole = (role: Role | string): Role => {
   const raw = typeof role === 'string' ? role : `${role}`;
   const sanitized = sanitizeRole(raw);
+
+  if (INVALID_ROLE_VALUES.has(sanitized)) {
+    return '' as Role;
+  }
+
   const alias = ROLE_ALIASES[sanitized];
 
   if (alias) {
@@ -47,4 +54,31 @@ export const ROLE_LABELS: Record<string, string> = {
   admin: 'Administrador',
   docente: 'Docente',
   padre: 'Padre',
+};
+
+const capitalizeWord = (word: string) =>
+  word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+
+export const resolveRoleLabel = (role: Role | string | null | undefined): string => {
+  if (typeof role !== 'string') {
+    return '';
+  }
+
+  const normalized = normalizeRole(role);
+
+  if (!normalized) {
+    return '';
+  }
+
+  const label = ROLE_LABELS[normalized];
+
+  if (label) {
+    return label;
+  }
+
+  return normalized
+    .split(' ')
+    .filter(Boolean)
+    .map(capitalizeWord)
+    .join(' ');
 };

--- a/src/pages/users/UsersList.tsx
+++ b/src/pages/users/UsersList.tsx
@@ -4,19 +4,14 @@ import { Link } from 'react-router-dom';
 
 import { deleteUser, getUsers, USERS_PAGE_SIZE } from '@/app/services/users';
 import { getRoleOptions } from '@/app/services/roles';
+import { resolveRoleLabel } from '@/app/utils/roles';
 import type { ManagedUser, Role, RoleOption } from '@/app/types';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
 type RoleFilter = Role | 'all';
 
-const formatRoleLabel = (role: Role) => {
-  const trimmed = role.trim();
-  if (!trimmed) {
-    return 'Sin rol';
-  }
-  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
-};
+const formatRoleLabel = (role: Role) => resolveRoleLabel(role) || 'Sin rol';
 
 export default function UsersList() {
   const [page, setPage] = useState(1);


### PR DESCRIPTION
## Summary
- treat placeholder values as invalid when normalizing roles and provide a helper to format them consistently
- show a friendly fallback instead of `undefined` in the top bar when a user has no recognizable role
- reuse the shared role label formatter in the users list so unknown roles display as "Sin rol"

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db4852c36c8325bb876be2861f70c8