### PR TITLE
Implement permission-based authentication flow and route guards

### DIFF
--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -1,8 +1,11 @@
+import type { JSX } from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { useAuth } from '@/app/hooks/useAuth';
+import type { ViewCode } from '@/app/types';
 
-const linkBase = 'block px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors';
+const linkBase =
+  'flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors text-sm';
 const linkClassName = ({ isActive }: { isActive: boolean }) =>
   isActive ? `${linkBase} bg-gray-200 font-semibold` : `${linkBase} text-gray-700`;
 
@@ -11,44 +14,187 @@ type SidebarProps = {
   onNavigate?: () => void;
 };
 
+type IconProps = {
+  className?: string;
+};
+
+type IconComponent = (props: IconProps) => JSX.Element;
+
 type NavItem = {
   to: string;
   label: string;
+  icon: IconComponent;
+  permission?: ViewCode | ViewCode[] | null;
 };
 
-const navItems: NavItem[] = [
-  { to: '/', label: 'Dashboard' },
-  { to: '/estudiantes', label: 'Estudiantes' },
-  { to: '/docentes', label: 'Docentes' },
-  { to: '/personas', label: 'Personas' },
-  { to: '/cursos', label: 'Cursos' },
-  { to: '/materias', label: 'Materias' },
-  { to: '/usuarios', label: 'Usuarios' },
-  { to: '/auditoria', label: 'Auditoría' },
+const IconHome: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m3 10.5 9-7.5 9 7.5V21a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 21z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 21v-6h6v6" />
+  </svg>
+);
+
+const IconUsers: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 6.75a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25a7.5 7.5 0 0 1 15 0"
+    />
+  </svg>
+);
+
+const IconId: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 5.25h15v13.5h-15z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 9h4.5M7.5 12h4.5M7.5 15h4.5" />
+  </svg>
+);
+
+const IconBook: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M4.5 5.25A2.25 2.25 0 0 1 6.75 3h10.5A2.25 2.25 0 0 1 19.5 5.25v13.5A2.25 2.25 0 0 0 17.25 21H6.75A2.25 2.25 0 0 0 4.5 18.75z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 7.5H15M8.25 10.5H15M8.25 13.5H12" />
+  </svg>
+);
+
+const IconStack: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="m12 3 8.25 4.5L12 12 3.75 7.5z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 12-8.25 4.5L3.75 12" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="m20.25 16.5-8.25 4.5-8.25-4.5" />
+  </svg>
+);
+
+const IconShield: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 3 4.5 6v5.25c0 4.358 2.912 8.385 7.028 9.75 4.116-1.365 7.028-5.392 7.028-9.75V6z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 12.75 11.25 14.25 14.25 9.75" />
+  </svg>
+);
+
+const IconAudit: IconComponent = ({ className = 'h-5 w-5' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+    aria-hidden
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5h-2.5A1.75 1.75 0 0 0 4 6.25v12.5A1.75 1.75 0 0 0 5.75 20.5h12.5A1.75 1.75 0 0 0 20 18.75v-2.5" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5v-1A1.5 1.5 0 0 1 9.75 2h2.5A1.5 1.5 0 0 1 13.75 3.5v1" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9h3.75M9 12h2.25M9 15h4.5M14.25 9h2.25" />
+    <circle cx="17" cy="17" r="3" />
+  </svg>
+);
+
+const navigationItems: NavItem[] = [
+  { to: '/', label: 'Dashboard', icon: IconHome, permission: null },
+  { to: '/estudiantes', label: 'Estudiantes', icon: IconUsers, permission: 'MATRICULAS' },
+  { to: '/docentes', label: 'Docentes', icon: IconUsers, permission: 'DOCENTES' },
+  { to: '/personas', label: 'Personas', icon: IconId, permission: ['PERSONAS', 'USUARIOS'] },
+  { to: '/cursos', label: 'Cursos', icon: IconBook, permission: 'CURSOS' },
+  { to: '/materias', label: 'Materias', icon: IconStack, permission: 'MATERIAS' },
+  { to: '/usuarios', label: 'Usuarios', icon: IconShield, permission: 'USUARIOS' },
+  { to: '/auditoria', label: 'Auditoría', icon: IconAudit, permission: 'AUDITORIA' },
 ];
 
+const hasPermission = (permission: NavItem['permission'], hasView: (code: ViewCode) => boolean) => {
+  if (!permission) {
+    return true;
+  }
+
+  const permissions = Array.isArray(permission) ? permission : [permission];
+  return permissions.some((code) => hasView(code));
+};
+
 export default function Sidebar({ className = '', onNavigate }: SidebarProps) {
-  const { user } = useAuth();
+  const { user, hasView } = useAuth();
 
   if (!user) {
     return null;
   }
 
+  const items = navigationItems.filter((item) => hasPermission(item.permission, hasView));
+
   return (
     <aside className={`w-64 bg-white p-4 flex flex-col gap-6 overflow-y-auto ${className}`}>
       <div className="font-bold text-xl">Académico</div>
       <nav className="space-y-1">
-        {navItems.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            end={item.to === '/'}
-            className={linkClassName}
-            onClick={onNavigate}
-          >
-            {item.label}
-          </NavLink>
-        ))}
+        {items.length === 0 ? (
+          <p className="text-sm text-gray-500">No tienes accesos asignados.</p>
+        ) : (
+          items.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === '/'}
+              className={linkClassName}
+              onClick={onNavigate}
+            >
+              <item.icon className="h-5 w-5" />
+              <span>{item.label}</span>
+            </NavLink>
+          ))
+        )}
       </nav>
     </aside>
   );

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useAuth } from '@/app/hooks/useAuth';
 import { resolveRoleLabel } from '@/app/utils/roles';
@@ -18,7 +18,7 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
     const name = typeof user.name === 'string' && user.name.trim() ? user.name.trim() : null;
     const username = typeof user.username === 'string' && user.username.trim() ? user.username.trim() : null;
     const displayNameValue = name ?? username ?? 'Usuario';
-    const roleLabelValue =
+    const resolvedRoleLabel =
       resolveRoleLabel(user.role) ||
       (typeof user.role === 'string' && user.role.trim()
         ? 'Sin rol'
@@ -26,8 +26,16 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
           ? 'Sin rol'
           : '');
 
+    const roleLabelValue = resolvedRoleLabel ? resolvedRoleLabel.toUpperCase() : '';
+
     return { displayName: displayNameValue, roleLabel: roleLabelValue };
   }, [user]);
+
+  const handleLogout = useCallback(() => {
+    void Promise.resolve(logout()).catch((error) => {
+      console.error('Error al cerrar sesión', error);
+    });
+  }, [logout]);
 
   return (
     <header className="h-14 border-b bg-white px-4 flex items-center justify-between sticky top-0 z-30">
@@ -55,13 +63,17 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
       </div>
       <div className="flex items-center gap-3">
         {user && (
-          <span className="text-xs sm:text-sm text-gray-600">
-            {displayName}
-            {roleLabel ? ` • ${roleLabel}` : ''}
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs sm:text-sm font-medium text-gray-700">{displayName}</span>
+            {roleLabel && (
+              <span className="inline-flex items-center rounded-full border border-gray-200 bg-gray-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-600">
+                {roleLabel}
+              </span>
+            )}
+          </div>
         )}
         <button
-          onClick={logout}
+          onClick={handleLogout}
           className="text-sm px-3 py-1 rounded bg-gray-900 text-white hover:bg-gray-800 transition-colors"
         >
           Salir

--- a/src/app/providers/AuthContext.ts
+++ b/src/app/providers/AuthContext.ts
@@ -5,19 +5,23 @@ import type { User, ViewCode } from '@/app/types';
 type AuthContextValue = {
   user: User | null;
   isAuthenticated: boolean;
+  isLoading: boolean;
   views: ViewCode[];
   hasView: (code: ViewCode) => boolean;
   login: (username: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void> | void;
+  refreshUser: () => Promise<User | null>;
 };
 
 export const AuthContext = createContext<AuthContextValue>({
   user: null,
   isAuthenticated: false,
+  isLoading: true,
   views: [],
   hasView: () => false,
   login: async () => {},
-  logout: () => {},
+  logout: async () => {},
+  refreshUser: async () => null,
 });
 
 export type { AuthContextValue };

--- a/src/app/router/AppRouter.tsx
+++ b/src/app/router/AppRouter.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import Layout from '@/app/components/Layout';
 import { useAuth } from '@/app/hooks/useAuth';
 import { ProtectedRoute } from '@/app/router/ProtectedRoute';
+import { RequireView } from '@/app/router/RequireView';
 import Dashboard from '@/pages/Dashboard';
 import Login from '@/pages/Login';
 import CourseForm from '@/pages/courses/CourseForm';
@@ -18,6 +19,7 @@ import PersonForm from '@/pages/people/PersonForm';
 import UsersList from '@/pages/users/UsersList';
 import UserForm from '@/pages/users/UserForm';
 import AuditLog from '@/pages/audit/AuditLog';
+import Forbidden from '@/pages/Forbidden';
 
 export default function AppRouter() {
   const { isAuthenticated } = useAuth();
@@ -30,25 +32,159 @@ export default function AppRouter() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
 
-          <Route path="estudiantes" element={<StudentsList />} />
-          <Route path="estudiantes/nuevo" element={<StudentForm />} />
-          <Route path="estudiantes/:studentId/editar" element={<StudentForm />} />
-          <Route path="docentes" element={<TeachersList />} />
-          <Route path="docentes/nuevo" element={<TeacherForm />} />
-          <Route path="docentes/:teacherId/editar" element={<TeacherForm />} />
-          <Route path="personas" element={<PeopleList />} />
-          <Route path="personas/nuevo" element={<PersonForm />} />
-          <Route path="personas/:personId/editar" element={<PersonForm />} />
-          <Route path="cursos" element={<CoursesList />} />
-          <Route path="cursos/nuevo" element={<CourseForm />} />
-          <Route path="cursos/:courseId/editar" element={<CourseForm />} />
-          <Route path="materias" element={<SubjectsList />} />
-          <Route path="materias/nuevo" element={<SubjectForm />} />
-          <Route path="materias/:subjectId/editar" element={<SubjectForm />} />
-          <Route path="usuarios" element={<UsersList />} />
-          <Route path="usuarios/nuevo" element={<UserForm />} />
-          <Route path="usuarios/:userId/editar" element={<UserForm />} />
-          <Route path="auditoria" element={<AuditLog />} />
+          <Route
+            path="estudiantes"
+            element={
+              <RequireView code="MATRICULAS">
+                <StudentsList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="estudiantes/nuevo"
+            element={
+              <RequireView code="MATRICULAS">
+                <StudentForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="estudiantes/:studentId/editar"
+            element={
+              <RequireView code="MATRICULAS">
+                <StudentForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="docentes"
+            element={
+              <RequireView code="DOCENTES">
+                <TeachersList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="docentes/nuevo"
+            element={
+              <RequireView code="DOCENTES">
+                <TeacherForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="docentes/:teacherId/editar"
+            element={
+              <RequireView code="DOCENTES">
+                <TeacherForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="personas"
+            element={
+              <RequireView code={["PERSONAS", "USUARIOS"]}>
+                <PeopleList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="personas/nuevo"
+            element={
+              <RequireView code={["PERSONAS", "USUARIOS"]}>
+                <PersonForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="personas/:personId/editar"
+            element={
+              <RequireView code={["PERSONAS", "USUARIOS"]}>
+                <PersonForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="cursos"
+            element={
+              <RequireView code="CURSOS">
+                <CoursesList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="cursos/nuevo"
+            element={
+              <RequireView code="CURSOS">
+                <CourseForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="cursos/:courseId/editar"
+            element={
+              <RequireView code="CURSOS">
+                <CourseForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="materias"
+            element={
+              <RequireView code="MATERIAS">
+                <SubjectsList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="materias/nuevo"
+            element={
+              <RequireView code="MATERIAS">
+                <SubjectForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="materias/:subjectId/editar"
+            element={
+              <RequireView code="MATERIAS">
+                <SubjectForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="usuarios"
+            element={
+              <RequireView code="USUARIOS">
+                <UsersList />
+              </RequireView>
+            }
+          />
+          <Route
+            path="usuarios/nuevo"
+            element={
+              <RequireView code="USUARIOS">
+                <UserForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="usuarios/:userId/editar"
+            element={
+              <RequireView code="USUARIOS">
+                <UserForm />
+              </RequireView>
+            }
+          />
+          <Route
+            path="auditoria"
+            element={
+              <RequireView code="AUDITORIA">
+                <AuditLog />
+              </RequireView>
+            }
+          />
+          <Route path="403" element={<Forbidden />} />
         </Route>
       </Route>
 

--- a/src/app/router/ProtectedRoute.tsx
+++ b/src/app/router/ProtectedRoute.tsx
@@ -3,7 +3,15 @@ import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/app/hooks/useAuth';
 
 export function ProtectedRoute() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-sm text-gray-600">
+        Verificando sesión…
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;

--- a/src/app/router/RequireView.tsx
+++ b/src/app/router/RequireView.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+
+import { useAuth } from '@/app/hooks/useAuth';
+import type { ViewCode } from '@/app/types';
+
+type RequireViewProps = {
+  code: ViewCode | ViewCode[];
+  children: ReactNode;
+};
+
+const ensureArray = (code: ViewCode | ViewCode[]): ViewCode[] => (Array.isArray(code) ? code : [code]);
+
+export function RequireView({ code, children }: RequireViewProps) {
+  const { hasView, isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return (
+      <div className="py-10 text-center text-sm text-gray-600">
+        Verificando permisos…
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  const requiredCodes = ensureArray(code);
+  const allowed = requiredCodes.some((item) => hasView(item));
+
+  if (!allowed) {
+    return <Navigate to="/403" replace state={{ from: location.pathname }} />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -2,24 +2,15 @@ import axios from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '/api',
+  withCredentials: true,
 });
 
 export const withTrailingSlash = (path: string) => (path.endsWith('/') ? path : `${path}/`);
-
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token');
-  if (token) {
-    config.headers = config.headers ?? {};
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
 
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error?.response?.status === 401) {
-      localStorage.removeItem('access_token');
       localStorage.removeItem('user');
       if (window.location.pathname !== '/login') {
         window.location.replace('/login');

--- a/src/app/services/auth.ts
+++ b/src/app/services/auth.ts
@@ -1,0 +1,202 @@
+import api from '@/app/services/api';
+import type { ApiUser, ApiView, View } from '@/app/types';
+import { normalizeViewCode } from '@/app/utils/views';
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const dedupeViews = (views: (ApiView | View)[]): (ApiView | View)[] => {
+  const map = new Map<string, ApiView | View>();
+
+  views.forEach((view, index) => {
+    const code = normalizeViewCode(view.codigo);
+    if (!code) {
+      return;
+    }
+
+    map.set(code, {
+      ...view,
+      id: typeof view.id === 'number' ? view.id : index + 1,
+      nombre: typeof view.nombre === 'string' && view.nombre.trim() ? view.nombre : code,
+      codigo: code,
+      descripcion:
+        typeof view.descripcion === 'string' && view.descripcion.trim() ? view.descripcion : null,
+    });
+  });
+
+  return Array.from(map.values());
+};
+
+const coerceViews = (value: unknown): (ApiView | View)[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    const collected: (ApiView | View)[] = [];
+    value.forEach((item, index) => {
+      if (typeof item === 'string' || typeof item === 'number') {
+        const code = normalizeViewCode(String(item));
+        if (code) {
+          collected.push({
+            id: index + 1,
+            nombre: code,
+            codigo: code,
+            descripcion: null,
+          });
+        }
+        return;
+      }
+
+      if (isRecord(item)) {
+        const rawCode =
+          'codigo' in item
+            ? item.codigo
+            : 'code' in item
+              ? item.code
+              : 'permiso' in item
+                ? item.permiso
+                : 'permission' in item
+                  ? item.permission
+                  : undefined;
+
+        if (rawCode === undefined || rawCode === null) {
+          return;
+        }
+
+        const code = normalizeViewCode(String(rawCode));
+        if (!code) {
+          return;
+        }
+
+        const id =
+          typeof item.id === 'number'
+            ? item.id
+            : typeof item.vista_id === 'number'
+              ? item.vista_id
+              : index + 1;
+        const nombre =
+          typeof item.nombre === 'string' && item.nombre.trim()
+            ? item.nombre
+            : typeof item.label === 'string' && item.label.trim()
+              ? item.label
+              : code;
+        const descripcion =
+          typeof item.descripcion === 'string' && item.descripcion.trim()
+            ? item.descripcion
+            : null;
+
+        collected.push({
+          id,
+          nombre,
+          codigo: code,
+          descripcion,
+        });
+      }
+    });
+
+    return dedupeViews(collected);
+  }
+
+  if (isRecord(value)) {
+    if (Array.isArray(value.items)) {
+      return coerceViews(value.items);
+    }
+    if (Array.isArray(value.data)) {
+      return coerceViews(value.data);
+    }
+    return dedupeViews(
+      Object.values(value).flatMap((item, index) =>
+        Array.isArray(item)
+          ? coerceViews(item)
+          : typeof item === 'string' || typeof item === 'number'
+            ? [
+                {
+                  id: index + 1,
+                  nombre: normalizeViewCode(String(item)),
+                  codigo: normalizeViewCode(String(item)),
+                  descripcion: null,
+                },
+              ]
+            : [],
+      ),
+    );
+  }
+
+  return [];
+};
+
+const collectViews = (sources: unknown[]): (ApiView | View)[] => {
+  const aggregated: (ApiView | View)[] = [];
+  sources.forEach((source) => {
+    const parsed = coerceViews(source);
+    if (parsed.length) {
+      aggregated.push(...parsed);
+    }
+  });
+  return dedupeViews(aggregated);
+};
+
+const fetchPermissionsFallback = async (): Promise<(ApiView | View)[]> => {
+  try {
+    const { data } = await api.get<unknown>('/me/permisos');
+    return collectViews([data]);
+  } catch (error) {
+    console.warn('Failed to fetch permissions from fallback endpoint', error);
+    return [];
+  }
+};
+
+export const authLogin = async (username: string, password: string) => {
+  const formData = new URLSearchParams();
+  formData.append('username', username);
+  formData.append('password', password);
+
+  await api.post('/auth/login', formData, {
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    withCredentials: true,
+  });
+};
+
+export const authLogout = async () => {
+  try {
+    await api.post('/auth/logout');
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('auth/logout endpoint returned an error', error);
+    }
+  }
+};
+
+export const fetchCurrentUser = async (): Promise<ApiUser> => {
+  const { data } = await api.get<unknown>('/auth/me');
+
+  if (!isRecord(data)) {
+    throw new Error('Respuesta inesperada al obtener el usuario actual');
+  }
+
+  const candidateUser = isRecord(data.user) ? data.user : data;
+  const user = isRecord(candidateUser) ? (candidateUser as ApiUser) : null;
+
+  if (!user) {
+    throw new Error('No se pudo determinar el usuario autenticado');
+  }
+
+  const views = collectViews([
+    data.vistas,
+    data.permissions,
+    data.permisos,
+    isRecord(data.user) ? data.user.vistas : undefined,
+    isRecord(data.user) ? data.user.permissions : undefined,
+    isRecord(data.user) ? data.user.permisos : undefined,
+    user.vistas,
+  ]);
+
+  const vistas = views.length > 0 ? views : await fetchPermissionsFallback();
+
+  return {
+    ...user,
+    vistas,
+  };
+};

--- a/src/app/utils/views.ts
+++ b/src/app/utils/views.ts
@@ -1,0 +1,34 @@
+import type { ApiView, View } from '@/app/types';
+
+export const normalizeViewCode = (code: ApiView['codigo'] | View['codigo'] | string) => {
+  return `${code ?? ''}`.trim().toUpperCase();
+};
+
+export const normalizeViews = (views?: (ApiView | View)[] | null): View[] => {
+  if (!Array.isArray(views)) {
+    return [];
+  }
+
+  const map = new Map<string, View>();
+
+  views.forEach((view, index) => {
+    const code = normalizeViewCode(view.codigo);
+    if (!code) {
+      return;
+    }
+
+    const id = typeof view.id === 'number' ? view.id : index + 1;
+    const nombre = typeof view.nombre === 'string' && view.nombre.trim() ? view.nombre : code;
+    const descripcion =
+      typeof view.descripcion === 'string' && view.descripcion.trim() ? view.descripcion : null;
+
+    map.set(code, {
+      id,
+      nombre,
+      codigo: code,
+      descripcion,
+    });
+  });
+
+  return Array.from(map.values());
+};

--- a/src/pages/Forbidden.tsx
+++ b/src/pages/Forbidden.tsx
@@ -1,0 +1,33 @@
+import { Link, useLocation } from 'react-router-dom';
+
+export default function Forbidden() {
+  const location = useLocation();
+  const from =
+    typeof location.state === 'object' && location.state !== null && 'from' in location.state
+      ? (location.state as { from?: string }).from
+      : undefined;
+
+  return (
+    <div className="max-w-lg mx-auto text-center py-16">
+      <h1 className="text-3xl font-bold text-gray-900">403</h1>
+      <p className="mt-2 text-lg font-semibold text-gray-800">No tienes permiso para ver esta sección.</p>
+      {from && (
+        <p className="mt-1 text-sm text-gray-500">Intentaste acceder a: <code>{from}</code></p>
+      )}
+      <div className="mt-6 flex justify-center gap-3">
+        <Link
+          to={from && from !== '/403' ? from : '/'}
+          className="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+        >
+          Volver
+        </Link>
+        <Link
+          to="/"
+          className="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800"
+        >
+          Ir al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/audit/AuditLog.tsx
+++ b/src/pages/audit/AuditLog.tsx
@@ -83,7 +83,7 @@ export default function AuditLog() {
                 const formattedDate = (() => {
                   try {
                     return dateTimeFormatter.format(new Date(entry.timestamp));
-                  } catch (error) {
+                  } catch {
                     return entry.timestamp;
                   }
                 })();

--- a/src/pages/users/UserForm.tsx
+++ b/src/pages/users/UserForm.tsx
@@ -140,16 +140,6 @@ export default function UserForm() {
     setForm((previous) => ({ ...previous, [field]: value }));
   };
 
-  if (isEditing && userQuery.isLoading) {
-    return <p>Cargando usuario…</p>;
-  }
-
-  if (isEditing && userQuery.isError) {
-    return <p className="text-red-600">No se pudo cargar la información del usuario.</p>;
-  }
-
-  const title = isEditing ? 'Editar usuario' : 'Nuevo usuario';
-
   const peopleOptions = useMemo<Person[]>(() => {
     if (!peopleQuery.data) {
       return [];
@@ -166,6 +156,16 @@ export default function UserForm() {
       return 0;
     });
   }, [peopleQuery.data]);
+
+  if (isEditing && userQuery.isLoading) {
+    return <p>Cargando usuario…</p>;
+  }
+
+  if (isEditing && userQuery.isError) {
+    return <p className="text-red-600">No se pudo cargar la información del usuario.</p>;
+  }
+
+  const title = isEditing ? 'Editar usuario' : 'Nuevo usuario';
 
   return (
     <div className="bg-white rounded-2xl shadow p-4 max-w-2xl">


### PR DESCRIPTION
## Summary
- switch the auth provider to rely on cookie-based login, refresh the current user from `/auth/me`, and expose loading/refresh helpers
- add permission-aware navigation, reusable view guards, and a 403 page that is shown on unauthorized access
- refresh the sidebar and topbar UI to display role badges and hide menu entries without permissions while resolving lint issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dca8d9ceb08325b52cf619b848b5d9