### PR TITLE
feat: support multi-role auth metadata

### DIFF
--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -18,13 +18,21 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
     const name = typeof user.name === 'string' && user.name.trim() ? user.name.trim() : null;
     const username = typeof user.username === 'string' && user.username.trim() ? user.username.trim() : null;
     const displayNameValue = name ?? username ?? 'Usuario';
+    const roleLabels = Array.isArray(user.roles)
+      ? user.roles
+          .map((role) => resolveRoleLabel(role))
+          .filter((label): label is string => Boolean(label && label.trim()))
+      : [];
+
     const resolvedRoleLabel =
-      resolveRoleLabel(user.role) ||
-      (typeof user.role === 'string' && user.role.trim()
-        ? 'Sin rol'
-        : user.role === null
-          ? 'Sin rol'
-          : '');
+      roleLabels.length > 0
+        ? roleLabels.join(' • ')
+        : resolveRoleLabel(user.role) ||
+            (typeof user.role === 'string' && user.role.trim()
+              ? 'Sin rol'
+              : user.role === null
+                ? 'Sin rol'
+                : '');
 
     const roleLabelValue = resolvedRoleLabel ? resolvedRoleLabel.toUpperCase() : '';
 

--- a/src/app/providers/AuthContext.ts
+++ b/src/app/providers/AuthContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-import type { User, ViewCode } from '@/app/types';
+import type { Role, User, ViewCode } from '@/app/types';
 
 type AuthContextValue = {
   user: User | null;
@@ -8,6 +8,8 @@ type AuthContextValue = {
   isLoading: boolean;
   views: ViewCode[];
   hasView: (code: ViewCode) => boolean;
+  roles: Role[];
+  hasRole: (role: Role | string) => boolean;
   login: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void> | void;
   refreshUser: () => Promise<User | null>;
@@ -19,6 +21,8 @@ export const AuthContext = createContext<AuthContextValue>({
   isLoading: true,
   views: [],
   hasView: () => false,
+  roles: [],
+  hasRole: () => false,
   login: async () => {},
   logout: async () => {},
   refreshUser: async () => null,

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -54,11 +54,13 @@ export interface User {
   username?: string | null;
   email?: string | null;
   role: Role | null;
+  roles: Role[];
   vistas: View[];
 }
 
-export interface ApiUser extends Omit<User, 'role' | 'vistas'> {
-  role?: ApiRole;
+export interface ApiUser extends Omit<User, 'role' | 'roles' | 'vistas'> {
+  role?: ApiRole | null;
+  roles?: ApiRole[] | null;
   vistas?: (ApiView | View)[] | null;
 }
 
@@ -214,12 +216,14 @@ export interface ManagedUser {
   name?: string | null;
   email?: string | null;
   role: Role | null;
+  roles: Role[];
   persona?: Person | null;
   persona_id?: number | null;
 }
 
-export interface ApiManagedUser extends Omit<ManagedUser, 'role'> {
-  role?: ApiRole;
+export interface ApiManagedUser extends Omit<ManagedUser, 'role' | 'roles'> {
+  role?: ApiRole | null;
+  roles?: ApiRole[] | null;
 }
 
 export interface UserPayload {

--- a/src/pages/users/UsersList.tsx
+++ b/src/pages/users/UsersList.tsx
@@ -8,7 +8,18 @@ import type { ManagedUser } from '@/app/types';
 
 const SEARCH_DEBOUNCE_MS = 300;
 
-const formatRoleLabel = (role: ManagedUser['role']) => resolveRoleLabel(role) || 'Sin rol';
+const formatRoleLabel = (user: ManagedUser) => {
+  if (Array.isArray(user.roles) && user.roles.length > 0) {
+    const labels = user.roles
+      .map((role) => resolveRoleLabel(role))
+      .filter((label): label is string => Boolean(label && label.trim()));
+    if (labels.length > 0) {
+      return labels.join(', ');
+    }
+  }
+
+  return resolveRoleLabel(user.role) || 'Sin rol';
+};
 
 export default function UsersList() {
   const [page, setPage] = useState(1);
@@ -102,7 +113,7 @@ export default function UsersList() {
               {users.map((user) => (
                 <tr key={user.id} className="border-b last:border-0">
                   <td className="py-2">{user.username}</td>
-                  <td>{formatRoleLabel(user.role)}</td>
+                  <td>{formatRoleLabel(user)}</td>
                   <td>
                     {user.persona
                       ? `${user.persona.apellidos} ${user.persona.nombres}`.trim()


### PR DESCRIPTION
## Summary
- parse `/auth/me` role context and permission caches so we keep permissions aligned with the backend changes
- expose normalized role lists via the auth provider/context and reuse them across the UI
- surface multi-role labels for the current user badge and user management table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcad26658c8325b1113ab25ca3130f