### PR TITLE
Handle unauthorized current user fetch gracefully

### DIFF
--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -72,6 +72,11 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const refreshUser = useCallback(async () => {
     try {
       const current = await fetchCurrentUser();
+      if (!current) {
+        persistUser(null);
+        return null;
+      }
+
       const normalized = normalizeUser(current);
       persistUser(normalized);
       return normalized;

--- a/src/app/services/auth.ts
+++ b/src/app/services/auth.ts
@@ -1,5 +1,6 @@
 import api from '@/app/services/api';
 import type { ApiUser, ApiView, Role, View } from '@/app/types';
+import { isAxiosError } from 'axios';
 import { normalizeRole } from '@/app/utils/roles';
 import { normalizeViewCode } from '@/app/utils/views';
 
@@ -231,8 +232,18 @@ export const authLogout = async () => {
   }
 };
 
-export const fetchCurrentUser = async (): Promise<ApiUser> => {
-  const { data } = await api.get<unknown>('/auth/me');
+export const fetchCurrentUser = async (): Promise<ApiUser | null> => {
+  let data: unknown;
+
+  try {
+    ({ data } = await api.get<unknown>('/auth/me'));
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 401) {
+      return null;
+    }
+
+    throw error;
+  }
 
   if (!isRecord(data)) {
     throw new Error('Respuesta inesperada al obtener el usuario actual');


### PR DESCRIPTION
## Summary
- return `null` when the current user endpoint responds with 401 to avoid noisy errors
- guard the auth provider refresh logic so it stops persisting invalid users when the request is unauthorized

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcb767afb883259ea8fc745affa151