### PR TITLE
Fix role badge when backend sends alternate role fields

### DIFF
--- a/src/app/services/auth.ts
+++ b/src/app/services/auth.ts
@@ -160,7 +160,7 @@ const collectViews = (sources: unknown[]): (ApiView | View)[] => {
   return dedupeViews(aggregated);
 };
 
-const ROLE_KEY_PATTERN = /(role|rol)/u;
+const ROLE_KEY_PATTERN = /(?:^|[\s._-])(rol|role|roles|perfil(?:es)?|profile|profiles|cargo|tipo[\s._-]*usuario(?:s)?|user[\s._-]*type(?:s)?)(?:$|[\s._-])/iu;
 
 const collectRoles = (sources: unknown[]): Role[] => {
   const roles = new Set<Role>();
@@ -189,7 +189,11 @@ const collectRoles = (sources: unknown[]): Role[] => {
           return;
         }
 
-        if (ROLE_KEY_PATTERN.test(key.toLowerCase())) {
+        const normalizedKey = key
+          .replace(/([a-z])([A-Z])/g, '$1_$2')
+          .toLowerCase();
+
+        if (ROLE_KEY_PATTERN.test(normalizedKey)) {
           visit(item);
         }
       });


### PR DESCRIPTION
## Summary
- expand the role key detection logic to cover backend synonyms like tipo_usuario, perfil, and cargo
- normalize camelCase keys before evaluating them so embedded role information is parsed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcc00be18c83258d6ba0ec1210f03a