### PR TITLE
Add fallbacks when verifying existing sessions

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || '/api',
   withCredentials: true,
+  timeout: 10000,
 });
 
 export const withTrailingSlash = (path: string) => (path.endsWith('/') ? path : `${path}/`);


### PR DESCRIPTION
## Summary
- add a request timeout to the shared API client so stalled calls fail quickly
- add a fallback timer in the auth provider to end the loading state if session verification hangs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcc29a3bac8325ab8ed9cce5b4f4b7