### PR TITLE
Handle empty role values in the topbar badge

### DIFF
--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -25,16 +25,11 @@ export default function Topbar({ onToggleSidebar }: TopbarProps) {
       : [];
 
     const resolvedRoleLabel =
-      roleLabels.length > 0
-        ? roleLabels.join(' • ')
-        : resolveRoleLabel(user.role) ||
-            (typeof user.role === 'string' && user.role.trim()
-              ? 'Sin rol'
-              : user.role === null
-                ? 'Sin rol'
-                : '');
+      roleLabels.length > 0 ? roleLabels.join(' • ') : resolveRoleLabel(user.role);
 
-    const roleLabelValue = resolvedRoleLabel ? resolvedRoleLabel.toUpperCase() : '';
+    const roleLabelValue = resolvedRoleLabel && resolvedRoleLabel.trim()
+      ? resolvedRoleLabel.toUpperCase()
+      : '';
 
     return { displayName: displayNameValue, roleLabel: roleLabelValue };
   }, [user]);

--- a/src/app/utils/roles.ts
+++ b/src/app/utils/roles.ts
@@ -24,7 +24,15 @@ const sanitizeRole = (value: string): string => {
   return candidate.replace(/\s+/g, ' ').trim();
 };
 
-const INVALID_ROLE_VALUES = new Set(['', 'undefined', 'null', 'none', 'ninguno']);
+const INVALID_ROLE_VALUES = new Set([
+  '',
+  'undefined',
+  'null',
+  'none',
+  'ninguno',
+  'sin rol',
+  'sinrol',
+]);
 
 export const normalizeRole = (role: Role | string | null | undefined): Role | null => {
   if (role === null || role === undefined) {


### PR DESCRIPTION
## Summary
- treat "sin rol" strings from the API as invalid roles during normalization
- hide the topbar role pill when no normalized role label is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcca1f413083259ff81a8376c970bf