### PR TITLE
Add person selection and payload handling to student and teacher forms

### DIFF
--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -104,10 +104,19 @@ export interface Student {
   persona?: Person | null;
 }
 
-export interface StudentPayload {
-  persona_id: number;
+type PersonAssociationPayload =
+  | {
+      persona_id: number;
+      persona?: never;
+    }
+  | {
+      persona_id?: never;
+      persona: PersonPayload;
+    };
+
+export type StudentPayload = PersonAssociationPayload & {
   codigo_est: string;
-}
+};
 
 export type StudentFilters = PaginationFilters;
 
@@ -169,11 +178,10 @@ export interface Teacher {
   persona?: Person | null;
 }
 
-export interface TeacherPayload {
-  persona_id: number;
+export type TeacherPayload = PersonAssociationPayload & {
   titulo?: string | null;
   profesion?: string | null;
-}
+};
 
 export type TeacherFilters = PaginationFilters;
 

--- a/src/pages/students/StudentForm.tsx
+++ b/src/pages/students/StudentForm.tsx
@@ -6,31 +6,98 @@ import { z } from 'zod';
 import { isAxiosError } from 'axios';
 
 import { createStudent, getStudent, updateStudent } from '@/app/services/students';
-import type { Paginated, Student, StudentPayload } from '@/app/types';
+import { SEX_CODES, SEX_LABELS } from '@/app/types';
+import type { Paginated, PersonPayload, Student, StudentPayload, Sexo } from '@/app/types';
 
-const studentSchema = z.object({
-  persona_id: z.coerce
-    .number({ invalid_type_error: 'Ingresa un ID de persona válido.' })
-    .int('El ID de la persona debe ser un número entero.')
-    .positive('El ID de la persona debe ser mayor a 0.'),
-  codigo_est: z
-    .string()
-    .trim()
-    .min(1, 'Ingresa el código del estudiante.')
-    .max(50, 'Máximo 50 caracteres.'),
-});
+type PersonMode = 'existing' | 'new';
+
+type PersonFormState = {
+  nombres: string;
+  apellidos: string;
+  sexo: '' | Sexo;
+  fecha_nacimiento: string;
+  celular: string;
+  direccion: string;
+  ci_numero: string;
+  ci_complemento: string;
+  ci_expedicion: string;
+};
 
 type StudentFormState = {
+  personMode: PersonMode;
   persona_id: string;
   codigo_est: string;
+  persona: PersonFormState;
 };
 
-type FieldErrors = Partial<Record<keyof StudentFormState, string>>;
+type PersonFieldErrors = Partial<Record<keyof PersonFormState, string>>;
 
-const initialValues: StudentFormState = {
+type FieldErrors = {
+  persona_id?: string;
+  codigo_est?: string;
+  persona?: PersonFieldErrors;
+};
+
+const codigoEstSchema = z
+  .string()
+  .trim()
+  .min(1, 'Ingresa el código del estudiante.')
+  .max(50, 'Máximo 50 caracteres.');
+
+const personSchema = z.object({
+  nombres: z.string().min(1, 'Ingresa los nombres').max(120, 'Máximo 120 caracteres'),
+  apellidos: z.string().min(1, 'Ingresa los apellidos').max(120, 'Máximo 120 caracteres'),
+  sexo: z.enum(SEX_CODES, { message: 'Selecciona un sexo válido' }),
+  fecha_nacimiento: z
+    .string()
+    .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/u, 'Ingresa una fecha válida (YYYY-MM-DD)'),
+  celular: z
+    .string()
+    .min(1, 'Ingresa el celular')
+    .max(20, 'Máximo 20 caracteres'),
+  direccion: z.string().max(255, 'Máximo 255 caracteres').optional(),
+  ci_numero: z.string().max(20, 'Máximo 20 caracteres').optional(),
+  ci_complemento: z.string().max(5, 'Máximo 5 caracteres').optional(),
+  ci_expedicion: z.string().max(5, 'Máximo 5 caracteres').optional(),
+});
+
+const studentSchema = z.discriminatedUnion('personMode', [
+  z.object({
+    personMode: z.literal('existing'),
+    persona_id: z.coerce
+      .number()
+      .refine((value) => Number.isFinite(value), {
+        message: 'Ingresa un ID de persona válido.',
+      })
+      .int('El ID de la persona debe ser un número entero.')
+      .positive('El ID de la persona debe ser mayor a 0.'),
+    codigo_est: codigoEstSchema,
+  }),
+  z.object({
+    personMode: z.literal('new'),
+    codigo_est: codigoEstSchema,
+    persona: personSchema,
+  }),
+]);
+
+const createEmptyPerson = (): PersonFormState => ({
+  nombres: '',
+  apellidos: '',
+  sexo: '',
+  fecha_nacimiento: '',
+  celular: '',
+  direccion: '',
+  ci_numero: '',
+  ci_complemento: '',
+  ci_expedicion: '',
+});
+
+const createInitialFormState = (): StudentFormState => ({
+  personMode: 'existing',
   persona_id: '',
   codigo_est: '',
-};
+  persona: createEmptyPerson(),
+});
 
 const extractErrorDetail = (value: unknown): string => {
   if (!value) {
@@ -100,7 +167,7 @@ export default function StudentForm() {
   const queryClient = useQueryClient();
   const { studentId } = useParams();
   const isEditing = Boolean(studentId);
-  const [form, setForm] = useState<StudentFormState>(initialValues);
+  const [form, setForm] = useState<StudentFormState>(() => createInitialFormState());
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [submitError, setSubmitError] = useState('');
 
@@ -112,12 +179,28 @@ export default function StudentForm() {
 
   useEffect(() => {
     if (studentQuery.data) {
+      const persona = studentQuery.data.persona;
+      const fechaNacimiento = persona?.fecha_nacimiento ?? '';
       setForm({
+        personMode: 'existing',
         persona_id: String(studentQuery.data.persona_id ?? ''),
         codigo_est: studentQuery.data.codigo_est ?? '',
+        persona: {
+          nombres: persona?.nombres ?? '',
+          apellidos: persona?.apellidos ?? '',
+          sexo: persona?.sexo ?? '',
+          fecha_nacimiento: fechaNacimiento ? fechaNacimiento.slice(0, 10) : '',
+          celular: persona?.celular ?? '',
+          direccion: persona?.direccion ?? '',
+          ci_numero: persona?.ci_numero ?? '',
+          ci_complemento: persona?.ci_complemento ?? '',
+          ci_expedicion: persona?.ci_expedicion ?? '',
+        },
       });
+    } else if (!isEditing) {
+      setForm(createInitialFormState());
     }
-  }, [studentQuery.data]);
+  }, [isEditing, studentQuery.data]);
 
   const mutation = useMutation({
     mutationFn: async (payload: StudentPayload) =>
@@ -135,16 +218,41 @@ export default function StudentForm() {
         const detail = extractErrorDetail(error.response.data);
         const normalizedDetail = detail.toLowerCase();
 
-        if (error.response.status === 404 && normalizedDetail.includes('persona no encontrada')) {
+        if (error.response.status === 404 && normalizedDetail.includes('persona')) {
           setFieldErrors((previous) => ({ ...previous, persona_id: 'La persona indicada no existe.' }));
           setSubmitError('');
           return;
         }
 
-        if (error.response.status === 400 && normalizedDetail.includes('codigo_est ya existe')) {
-          setFieldErrors((previous) => ({ ...previous, codigo_est: 'El código de estudiante ya existe.' }));
-          setSubmitError('');
-          return;
+        if (error.response.status === 400) {
+          if (normalizedDetail.includes('codigo_est') && (normalizedDetail.includes('existe') || normalizedDetail.includes('registrad'))) {
+            setFieldErrors((previous) => ({ ...previous, codigo_est: 'El código de estudiante ya está registrado.' }));
+            setSubmitError('');
+            return;
+          }
+
+          if (normalizedDetail.includes('persona') && normalizedDetail.includes('registrad')) {
+            if (form.personMode === 'existing') {
+              setFieldErrors((previous) => ({
+                ...previous,
+                persona_id: 'La persona indicada ya está registrada como estudiante.',
+              }));
+              setSubmitError('');
+            } else {
+              setSubmitError('La persona ingresada ya está registrada como estudiante.');
+            }
+            return;
+          }
+
+          if (normalizedDetail.includes('ci ya registrado')) {
+            setSubmitError('El número de CI ingresado ya está registrado.');
+            return;
+          }
+
+          if (detail) {
+            setSubmitError(detail);
+            return;
+          }
         }
 
         setSubmitError(detail || 'No se pudo guardar.');
@@ -155,37 +263,119 @@ export default function StudentForm() {
     },
   });
 
+  const clearPersonaError = (field: keyof PersonFormState) => {
+    setFieldErrors((previous) => {
+      if (!previous.persona || !previous.persona[field]) {
+        return previous;
+      }
+      const nextPersona = { ...previous.persona };
+      delete nextPersona[field];
+      const next: FieldErrors = { ...previous };
+      if (Object.keys(nextPersona).length > 0) {
+        next.persona = nextPersona;
+      } else {
+        delete next.persona;
+      }
+      return next;
+    });
+  };
+
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setSubmitError('');
 
-    const result = studentSchema.safeParse({
-      persona_id: form.persona_id,
-      codigo_est: form.codigo_est,
-    });
+    const trimmedCodigo = form.codigo_est.trim();
+    const personaInput = {
+      nombres: form.persona.nombres.trim(),
+      apellidos: form.persona.apellidos.trim(),
+      sexo: form.persona.sexo,
+      fecha_nacimiento: form.persona.fecha_nacimiento,
+      celular: form.persona.celular.trim(),
+      direccion: form.persona.direccion.trim() || undefined,
+      ci_numero: form.persona.ci_numero.trim() || undefined,
+      ci_complemento: form.persona.ci_complemento.trim() || undefined,
+      ci_expedicion: form.persona.ci_expedicion.trim() || undefined,
+    };
+
+    const payloadInput =
+      form.personMode === 'existing'
+        ? {
+            personMode: 'existing' as const,
+            persona_id: form.persona_id.trim(),
+            codigo_est: trimmedCodigo,
+          }
+        : {
+            personMode: 'new' as const,
+            codigo_est: trimmedCodigo,
+            persona: personaInput,
+          };
+
+    const result = studentSchema.safeParse(payloadInput);
 
     if (!result.success) {
       const newErrors: FieldErrors = {};
       for (const issue of result.error.issues) {
-        const field = issue.path[0];
-        if (typeof field === 'string' && !(field in newErrors)) {
-          newErrors[field as keyof StudentFormState] = issue.message;
+        const [first, second] = issue.path;
+        if (first === 'persona' && typeof second === 'string') {
+          const personaErrors = { ...(newErrors.persona ?? {}) };
+          if (!personaErrors[second as keyof PersonFormState]) {
+            personaErrors[second as keyof PersonFormState] = issue.message;
+          }
+          newErrors.persona = personaErrors;
+          continue;
+        }
+
+        if (typeof first === 'string' && !(first in newErrors)) {
+          (newErrors as Record<string, string>)[first] = issue.message;
         }
       }
       setFieldErrors(newErrors);
       return;
     }
 
-    const payload: StudentPayload = {
-      persona_id: result.data.persona_id,
-      codigo_est: result.data.codigo_est,
-    };
+    let payload: StudentPayload;
+
+    if (result.data.personMode === 'existing') {
+      payload = {
+        persona_id: result.data.persona_id,
+        codigo_est: result.data.codigo_est,
+      };
+    } else {
+      const personaPayload: PersonPayload = {
+        nombres: result.data.persona.nombres,
+        apellidos: result.data.persona.apellidos,
+        sexo: result.data.persona.sexo,
+        fecha_nacimiento: result.data.persona.fecha_nacimiento,
+        celular: result.data.persona.celular,
+      };
+
+      if (result.data.persona.direccion) {
+        personaPayload.direccion = result.data.persona.direccion;
+      }
+
+      if (result.data.persona.ci_numero) {
+        personaPayload.ci_numero = result.data.persona.ci_numero;
+      }
+
+      if (result.data.persona.ci_complemento) {
+        personaPayload.ci_complemento = result.data.persona.ci_complemento;
+      }
+
+      if (result.data.persona.ci_expedicion) {
+        personaPayload.ci_expedicion = result.data.persona.ci_expedicion;
+      }
+
+      payload = {
+        codigo_est: result.data.codigo_est,
+        persona: personaPayload,
+      };
+    }
 
     setFieldErrors({});
     mutation.mutate(payload);
   };
 
-  const updateField = (field: keyof StudentFormState) => (value: string) => {
+  const updateTopLevelField = (field: 'persona_id' | 'codigo_est') => (value: string) => {
     setSubmitError('');
     setFieldErrors((previous) => {
       if (!previous[field]) {
@@ -196,6 +386,50 @@ export default function StudentForm() {
       return next;
     });
     setForm((previous) => ({ ...previous, [field]: value }));
+  };
+
+  const updatePersonaField = (field: keyof PersonFormState) => (value: string) => {
+    setSubmitError('');
+    clearPersonaError(field);
+    setForm((previous) => ({
+      ...previous,
+      persona: {
+        ...previous.persona,
+        [field]: value,
+      },
+    }));
+  };
+
+  const handlePersonModeChange = (mode: PersonMode) => {
+    setSubmitError('');
+    setFieldErrors((previous) => {
+      if (mode === 'existing') {
+        if (!previous.persona) {
+          return previous;
+        }
+        const next = { ...previous };
+        delete next.persona;
+        return next;
+      }
+
+      if (!previous.persona_id) {
+        return previous;
+      }
+
+      const next = { ...previous };
+      delete next.persona_id;
+      return next;
+    });
+
+    setForm((previous) => ({
+      ...previous,
+      personMode: mode,
+      persona_id: mode === 'existing' ? previous.persona_id : '',
+      persona:
+        mode === 'new' && previous.personMode === 'existing'
+          ? createEmptyPerson()
+          : previous.persona,
+    }));
   };
 
   if (isEditing && studentQuery.isLoading) {
@@ -209,22 +443,198 @@ export default function StudentForm() {
   const title = isEditing ? 'Editar estudiante' : 'Nuevo estudiante';
 
   return (
-    <div className="bg-white rounded-2xl shadow p-4 max-w-xl">
+    <div className="bg-white rounded-2xl shadow p-4 max-w-3xl">
       <h1 className="text-lg font-semibold mb-4">{title}</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-600" htmlFor="student-persona-id">
-            ID de la persona
-          </label>
-          <input
-            id="student-persona-id"
-            className="w-full border rounded px-3 py-2"
-            value={form.persona_id}
-            onChange={(event) => updateField('persona_id')(event.target.value)}
-            inputMode="numeric"
-          />
-          {fieldErrors.persona_id && <p className="text-sm text-red-600 mt-1">{fieldErrors.persona_id}</p>}
+          <span className="block text-sm font-medium text-gray-600">Persona asociada</span>
+          <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="student-person-mode"
+                value="existing"
+                checked={form.personMode === 'existing'}
+                onChange={() => handlePersonModeChange('existing')}
+              />
+              Vincular persona existente
+            </label>
+            <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="student-person-mode"
+                value="new"
+                checked={form.personMode === 'new'}
+                onChange={() => handlePersonModeChange('new')}
+              />
+              Registrar nueva persona
+            </label>
+          </div>
         </div>
+
+        {form.personMode === 'existing' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-600" htmlFor="student-persona-id">
+              ID de la persona
+            </label>
+            <input
+              id="student-persona-id"
+              className="w-full border rounded px-3 py-2"
+              value={form.persona_id}
+              onChange={(event) => updateTopLevelField('persona_id')(event.target.value)}
+              inputMode="numeric"
+            />
+            {fieldErrors.persona_id && <p className="text-sm text-red-600 mt-1">{fieldErrors.persona_id}</p>}
+          </div>
+        )}
+
+        {form.personMode === 'new' && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-nombres">
+                  Nombres
+                </label>
+                <input
+                  id="student-person-nombres"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.nombres}
+                  onChange={(event) => updatePersonaField('nombres')(event.target.value)}
+                />
+                {fieldErrors.persona?.nombres && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.nombres}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-apellidos">
+                  Apellidos
+                </label>
+                <input
+                  id="student-person-apellidos"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.apellidos}
+                  onChange={(event) => updatePersonaField('apellidos')(event.target.value)}
+                />
+                {fieldErrors.persona?.apellidos && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.apellidos}</p>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-sexo">
+                  Sexo
+                </label>
+                <select
+                  id="student-person-sexo"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.sexo}
+                  onChange={(event) => updatePersonaField('sexo')(event.target.value as PersonFormState['sexo'])}
+                >
+                  <option value="">Selecciona…</option>
+                  {SEX_CODES.map((option) => (
+                    <option key={option} value={option}>
+                      {SEX_LABELS[option]}
+                    </option>
+                  ))}
+                </select>
+                {fieldErrors.persona?.sexo && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.sexo}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-fecha-nacimiento">
+                  Fecha de nacimiento
+                </label>
+                <input
+                  type="date"
+                  id="student-person-fecha-nacimiento"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.fecha_nacimiento}
+                  onChange={(event) => updatePersonaField('fecha_nacimiento')(event.target.value)}
+                />
+                {fieldErrors.persona?.fecha_nacimiento && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.fecha_nacimiento}</p>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-celular">
+                  Celular
+                </label>
+                <input
+                  id="student-person-celular"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.celular}
+                  onChange={(event) => updatePersonaField('celular')(event.target.value)}
+                />
+                {fieldErrors.persona?.celular && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.celular}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-direccion">
+                  Dirección
+                </label>
+                <input
+                  id="student-person-direccion"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.direccion}
+                  onChange={(event) => updatePersonaField('direccion')(event.target.value)}
+                />
+                {fieldErrors.persona?.direccion && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.direccion}</p>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-ci-numero">
+                  N° de CI (opcional)
+                </label>
+                <input
+                  id="student-person-ci-numero"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.ci_numero}
+                  onChange={(event) => updatePersonaField('ci_numero')(event.target.value)}
+                />
+                {fieldErrors.persona?.ci_numero && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.ci_numero}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-ci-complemento">
+                  Complemento
+                </label>
+                <input
+                  id="student-person-ci-complemento"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.ci_complemento}
+                  onChange={(event) => updatePersonaField('ci_complemento')(event.target.value)}
+                />
+                {fieldErrors.persona?.ci_complemento && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.ci_complemento}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-600" htmlFor="student-person-ci-expedicion">
+                  Expedición
+                </label>
+                <input
+                  id="student-person-ci-expedicion"
+                  className="w-full border rounded px-3 py-2"
+                  value={form.persona.ci_expedicion}
+                  onChange={(event) => updatePersonaField('ci_expedicion')(event.target.value)}
+                />
+                {fieldErrors.persona?.ci_expedicion && (
+                  <p className="text-sm text-red-600 mt-1">{fieldErrors.persona.ci_expedicion}</p>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
         <div>
           <label className="block text-sm font-medium text-gray-600" htmlFor="student-codigo">
             Código de estudiante
@@ -233,11 +643,12 @@ export default function StudentForm() {
             id="student-codigo"
             className="w-full border rounded px-3 py-2"
             value={form.codigo_est}
-            onChange={(event) => updateField('codigo_est')(event.target.value)}
+            onChange={(event) => updateTopLevelField('codigo_est')(event.target.value)}
             maxLength={50}
           />
           {fieldErrors.codigo_est && <p className="text-sm text-red-600 mt-1">{fieldErrors.codigo_est}</p>}
         </div>
+
         {submitError && <p className="text-red-600 text-sm">{submitError}</p>}
         <div className="flex gap-2 justify-end">
           <button type="button" className="px-3 py-2 border rounded" onClick={() => navigate(-1)}>


### PR DESCRIPTION
## Summary
- let student and teacher forms pick between linking an existing persona_id or registering a new persona and validate the choice on the client
- build persona payloads when creating people, wiring optional CI fields and improved API error handling for duplicate codes or documents
- update shared payload typings so estudiantes/docentes endpoints accept either persona_id references or embedded personas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd819427208325a710e0c729633e83