### PR TITLE
Ensure student API calls include trailing slash

### DIFF
--- a/src/app/services/students.ts
+++ b/src/app/services/students.ts
@@ -1,4 +1,4 @@
-import api, { withAuth } from '@/app/services/api';
+import api, { withAuth, withTrailingSlash } from '@/app/services/api';
 import { normalizePaginatedResponse } from '@/app/services/pagination';
 import type { Paginated, PaginatedResponse, Student, StudentFilters, StudentPayload } from '@/app/types';
 
@@ -17,25 +17,25 @@ export async function getStudents(filters: StudentFilters): Promise<Paginated<St
     params.search = search.trim();
   }
 
-  const { data } = await api.get<PaginatedResponse<Student>>(STUDENTS_ENDPOINT, withAuth({ params }));
+  const { data } = await api.get<PaginatedResponse<Student>>(withTrailingSlash(STUDENTS_ENDPOINT), withAuth({ params }));
   return normalizePaginatedResponse(data);
 }
 
 export async function createStudent(payload: StudentPayload) {
-  const { data } = await api.post<Student>(STUDENTS_ENDPOINT, payload, withAuth());
+  const { data } = await api.post<Student>(withTrailingSlash(STUDENTS_ENDPOINT), payload, withAuth());
   return data;
 }
 
 export async function getStudent(id: number) {
-  const { data } = await api.get<Student>(`${STUDENTS_ENDPOINT}/${id}`, withAuth());
+  const { data } = await api.get<Student>(`${withTrailingSlash(STUDENTS_ENDPOINT)}${id}`, withAuth());
   return data;
 }
 
 export async function updateStudent(id: number, payload: StudentPayload) {
-  const { data } = await api.patch<Student>(`${STUDENTS_ENDPOINT}/${id}`, payload, withAuth());
+  const { data } = await api.patch<Student>(`${withTrailingSlash(STUDENTS_ENDPOINT)}${id}`, payload, withAuth());
   return data;
 }
 
 export async function deleteStudent(id: number) {
-  await api.delete(`${STUDENTS_ENDPOINT}/${id}`, withAuth());
+  await api.delete(`${withTrailingSlash(STUDENTS_ENDPOINT)}${id}`, withAuth());
 }


### PR DESCRIPTION
## Summary
- import the withTrailingSlash helper in the students service
- ensure every student request builds its URL with a trailing slash to avoid backend redirects

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda30a016883259a8ab6fb13350945